### PR TITLE
Add ClusterScoped

### DIFF
--- a/pkg/relatedresource/changeset.go
+++ b/pkg/relatedresource/changeset.go
@@ -11,6 +11,12 @@ import (
 	"k8s.io/client-go/tools/cache"
 )
 
+/*
+	The related resource pkg allows for the chaining of disparate objects via a shared informer.
+	It requires that the caller be able to provide a Resolver and a Enqueuer function.
+	The Resolver should be able to return a Key for the specified object
+
+*/
 type Key struct {
 	Namespace string
 	Name      string
@@ -31,12 +37,22 @@ type ControllerWrapper interface {
 type Enqueuer interface {
 	Enqueue(namespace, name string)
 }
+type EnqueuerClusterScope interface {
+	Enqueue(name string)
+}
 
 type Resolver func(namespace, name string, obj runtime.Object) ([]Key, error)
+type ResolverClusterScope func(name string, obj runtime.Object) ([]Key, error)
 
 func Watch(ctx context.Context, name string, resolve Resolver, enq Enqueuer, watching ...ControllerWrapper) {
 	for _, c := range watching {
 		watch(ctx, name, resolve, enq, c)
+	}
+}
+
+func WatchClusterScope(ctx context.Context, name string, resolve ResolverClusterScope, enq EnqueuerClusterScope, watching ...ControllerWrapper) {
+	for _, c := range watching {
+		watchClusterScope(ctx, name, resolve, enq, c)
 	}
 }
 
@@ -75,5 +91,42 @@ func watch(ctx context.Context, name string, resolve Resolver, enq Enqueuer, con
 	controller.AddGenericHandler(ctx, name, func(key string, obj runtime.Object) (runtime.Object, error) {
 		ns, name := kv.Split(key, "/")
 		return obj, runResolve(ns, name, obj)
+	})
+}
+
+func watchClusterScope(ctx context.Context, name string, resolve ResolverClusterScope, enq EnqueuerClusterScope, controller ControllerWrapper) {
+	runResolve := func(name string, obj runtime.Object) error {
+		keys, err := resolve(name, obj)
+		if err != nil {
+			return err
+		}
+
+		for _, key := range keys {
+			if key.Name != "" {
+				enq.Enqueue(key.Name)
+			}
+		}
+
+		return nil
+	}
+
+	controller.Informer().AddEventHandler(cache.ResourceEventHandlerFuncs{
+		DeleteFunc: func(obj interface{}) {
+			ro, ok := obj.(runtime.Object)
+			if !ok {
+				return
+			}
+
+			meta, err := meta.Accessor(ro)
+			if err != nil {
+				return
+			}
+			runResolve(meta.GetName(), ro)
+		},
+	})
+
+	controller.AddGenericHandler(ctx, name, func(key string, obj runtime.Object) (runtime.Object, error) {
+		_, name := kv.Split(key, "/")
+		return obj, runResolve(name, obj)
 	})
 }

--- a/pkg/relatedresource/changeset.go
+++ b/pkg/relatedresource/changeset.go
@@ -36,11 +36,11 @@ type Resolver func(namespace, name string, obj runtime.Object) ([]Key, error)
 
 func Watch(ctx context.Context, name string, resolve Resolver, enq Enqueuer, watching ...ControllerWrapper) {
 	for _, c := range watching {
-		watch(ctx, name, enq, resolve, c)
+		watch(ctx, name, resolve, enq, c)
 	}
 }
 
-func watch(ctx context.Context, name string, enq Enqueuer, resolve Resolver, controller ControllerWrapper) {
+func watch(ctx context.Context, name string, resolve Resolver, enq Enqueuer, controller ControllerWrapper) {
 	runResolve := func(ns, name string, obj runtime.Object) error {
 		keys, err := resolve(ns, name, obj)
 		if err != nil {


### PR DESCRIPTION
Change Exported and unexported function to have a similar func
signature

Add ClusterScoped functions to allow for watching of objects whose `Enqueue` functions only take a name and no namespace. 