### PR TITLE
fix spurious replace wait errors

### DIFF
--- a/pkg/apply/desiredset_crud.go
+++ b/pkg/apply/desiredset_crud.go
@@ -51,8 +51,8 @@ func (o *desiredSet) get(nsed bool, namespace, name string, client dynamic.Names
 	return client.Get(name, v1.GetOptions{})
 }
 
-func (o *desiredSet) delete(nsed bool, namespace, name string, client dynamic.NamespaceableResourceInterface) error {
-	if o.noDelete {
+func (o *desiredSet) delete(nsed bool, namespace, name string, client dynamic.NamespaceableResourceInterface, force bool) error {
+	if o.noDelete && !force {
 		return nil
 	}
 	opts := &v1.DeleteOptions{

--- a/pkg/apply/desiredset_process.go
+++ b/pkg/apply/desiredset_process.go
@@ -239,8 +239,8 @@ func (o *desiredSet) process(debugID string, set labels.Selector, gvk schema.Gro
 		logrus.Debugf("DesiredSet - Created %s %s for %s", gvk, k, debugID)
 	}
 
-	deleteF := func(k objectset.ObjectKey) {
-		if err := o.delete(nsed, k.Namespace, k.Name, client); err != nil {
+	deleteF := func(k objectset.ObjectKey, force bool) {
+		if err := o.delete(nsed, k.Namespace, k.Name, client, force); err != nil {
 			o.err(errors.Wrapf(err, "failed to delete %s %s for %s", k, gvk, debugID))
 			return
 		}
@@ -250,7 +250,7 @@ func (o *desiredSet) process(debugID string, set labels.Selector, gvk schema.Gro
 	updateF := func(k objectset.ObjectKey) {
 		err := o.compareObjects(gvk, patcher, client, debugID, existing[k], objs[k], len(toCreate) > 0 || len(toDelete) > 0)
 		if err == ErrReplace {
-			deleteF(k)
+			deleteF(k, true)
 			o.err(fmt.Errorf("DesiredSet - Replace Wait %s %s for %s", gvk, k, debugID))
 		} else if err != nil {
 			o.err(errors.Wrapf(err, "failed to update %s %s for %s", k, gvk, debugID))
@@ -266,7 +266,7 @@ func (o *desiredSet) process(debugID string, set labels.Selector, gvk schema.Gro
 	}
 
 	for _, k := range toDelete {
-		deleteF(k)
+		deleteF(k, false)
 	}
 }
 


### PR DESCRIPTION
This address an issue in rancher/system-upgrade-controller#25 when generating objects `WithNoDelete()` where the replace logic fails with noisy 'Replace Wait' errors in the log.
This also mitigates the no-delete+replace logic swamping the rate limit for a custom type.