### PR TITLE
Fixes Required for OpenAPI V3 Scheme Validation

### DIFF
--- a/pkg/schemas/openapi/generate.go
+++ b/pkg/schemas/openapi/generate.go
@@ -99,7 +99,7 @@ func parseSchema(schema *types.Schema, schemas *types.Schemas) (*v1beta1.JSONSch
 		//}
 
 		if f.Required {
-			fieldJSP.Required = append(fieldJSP.Required, name)
+			jsp.Required = append(jsp.Required, name)
 		}
 
 		if definition.IsMapType(f.Type) {
@@ -166,6 +166,7 @@ func parseSchema(schema *types.Schema, schemas *types.Schemas) (*v1beta1.JSONSch
 					return nil, err
 				}
 				fieldJSP.Properties = subObject.Properties
+				fieldJSP.Required = subObject.Required
 			}
 		}
 


### PR DESCRIPTION
This change couldn't be applied cleanly to master, I didn't look to try and fix master yet, hoping to just get this backported to 0.5.3 for now, perhaps you can fix in master as well (or maybe it is already?)

Resolves #80