### PR TITLE
Wrap error from gvk

### DIFF
--- a/pkg/yaml/yaml.go
+++ b/pkg/yaml/yaml.go
@@ -114,7 +114,7 @@ func CleanObjectForExport(obj runtime.Object) (runtime.Object, error) {
 		if gvk, err := gvk.Get(obj); err == nil {
 			obj.GetObjectKind().SetGroupVersionKind(gvk)
 		} else if err != nil {
-			return nil, fmt.Errorf("kind and/or apiVersion is not set on input object: %v", obj)
+			return nil, errors.Wrapf(err, "kind and/or apiVersion is not set on input object: %v", obj)
 		}
 	}
 


### PR DESCRIPTION
Prior, the error returned from the gvk package Get function was
not included in the returned error. This error may contain
actionable advice on resolving the error. For example, suggesting
that the user import the generated controller package so that its
init function is called.