### PR TITLE
Drop resourceVersion on lists when set to 0

### DIFF
--- a/pkg/summary/informer/informer.go
+++ b/pkg/summary/informer/informer.go
@@ -126,6 +126,12 @@ func NewFilteredSummaryInformer(client client.Interface, gvr schema.GroupVersion
 					if tweakListOptions != nil {
 						tweakListOptions(&options)
 					}
+					// If ResourceVersion is set to 0 then the Limit is ignored on the API side. Usually
+					// that's not a problem, but with very large counts of a single object type the client will
+					// hit it's connection timeout
+					if options.ResourceVersion == "0" {
+						options.ResourceVersion = ""
+					}
 					return client.Resource(gvr).Namespace(namespace).List(context.TODO(), options)
 				},
 				WatchFunc: func(options metav1.ListOptions) (watch.Interface, error) {


### PR DESCRIPTION
Problem:
In a cluster with a large number of a single object, say 10k large
secrets, when the controller starts it attempts to list all of those
secrets and hits the client timeout

Solution:
Just increasing the client timeout does not work as the API server also
has a timeout. The API server ignores the limit when resourceVersion is
set to 0 which causes the call to take longer than either timeout
(running curl against the API server the call was taking over 3min on
average and pulling approx 2GB of data) so if resourceVersion is set to
0 reset it to empty string