### PR TITLE
Fix crd generation code

### DIFF
--- a/pkg/schemas/openapi/generate.go
+++ b/pkg/schemas/openapi/generate.go
@@ -111,6 +111,7 @@ func typeToProps(typeName string, schemas *types.Schemas, inflight map[string]bo
 		jsp.Nullable = true
 		if additionalProps.Type != "object" {
 			jsp.AdditionalProperties = &v1beta1.JSONSchemaPropsOrBool{
+				Allows: true,
 				Schema: additionalProps,
 			}
 		}


### PR DESCRIPTION
This commit addes allow: true so that when comparing crd generated from
wranger code and crd from api server, where api server/client-go will modify the
field to true.