### PR TITLE
added check in SafeConcatName

### DIFF
--- a/pkg/name/name.go
+++ b/pkg/name/name.go
@@ -51,9 +51,16 @@ func Hex(s string, length int) string {
 
 func SafeConcatName(name ...string) string {
 	fullPath := strings.Join(name, "-")
-	if len(fullPath) > 63 {
-		digest := sha256.Sum256([]byte(fullPath))
+	if len(fullPath) < 64 {
+		return fullPath
+	}
+	digest := sha256.Sum256([]byte(fullPath))
+	// since we cut the string in the middle, the last char may not be compatible with what is expected in k8s
+	// we are checking and if necessary removing the last char
+	c := fullPath[56]
+	if 'a' <= c && c <= 'z' || '0' <= c && c <= '9' {
 		return fullPath[0:57] + "-" + hex.EncodeToString(digest[0:])[0:5]
 	}
-	return fullPath
+
+	return fullPath[0:56] + "-" + hex.EncodeToString(digest[0:])[0:6]
 }


### PR DESCRIPTION
If the name is bigger than 63 characters the name is cut and the last character might violate the regexp check for valid k8s name.
Added a check for the last character in SafeConcatName to remedy this.

Resolves [issue](https://github.com/rancher/system-upgrade-controller/issues/110)

Signed-off-by: Birol Bilgin <birolbilgin@gmail.com>