### PR TITLE
adding default support

### DIFF
--- a/pkg/crd/init.go
+++ b/pkg/crd/init.go
@@ -15,8 +15,8 @@ import (
 	"github.com/rancher/wrangler/pkg/name"
 	"github.com/rancher/wrangler/pkg/schemas/openapi"
 	"github.com/sirupsen/logrus"
-	"k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
 	apiext "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
+	v1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
 	"k8s.io/apiextensions-apiserver/pkg/client/clientset/clientset"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/api/meta"
@@ -243,6 +243,7 @@ func (c CRD) ToCustomResourceDefinition() (runtime.Object, error) {
 				Categories: c.Categories,
 				ShortNames: c.ShortNames,
 			},
+			PreserveUnknownFields: false,
 		},
 	}
 

--- a/pkg/schemas/openapi/generate.go
+++ b/pkg/schemas/openapi/generate.go
@@ -7,7 +7,7 @@ import (
 
 	types "github.com/rancher/wrangler/pkg/schemas"
 	"github.com/rancher/wrangler/pkg/schemas/definition"
-	"k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
+	v1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
 )
 
 func MustGenerate(obj interface{}) *v1.JSONSchemaProps {
@@ -87,6 +87,16 @@ func populateField(fieldJSP *v1.JSONSchemaProps, f *types.Field) error {
 		fieldJSP.Maximum = &fl
 	}
 
+	if f.Default != nil {
+		bytes, err := json.Marshal(f.Default)
+		if err != nil {
+			return err
+		}
+		fieldJSP.Default = &v1.JSON{
+			Raw: bytes,
+		}
+	}
+
 	return nil
 }
 
@@ -132,6 +142,8 @@ func typeToProps(typeName string, schemas *types.Schemas, inflight map[string]bo
 	default:
 		jsp.Type = t
 	}
+
+	jsp.XPreserveUnknownFields = nil
 
 	return jsp, nil
 }


### PR DESCRIPTION
Totally stealing code from @ibuildthecloud that he gave me but this adds default tag support to wrangler with one big caveat.

The caveat is that you have to set `crd.spec.preserveUnknownFields` to `false` but you CANNOT do this at the same time as adding a schema that has defaults defined :(

You must first set `preserveUnknownFields` to `false` then you can apply the CRD with defaults which is set to true by default in v1beta1 it seems.

**Question:** would it make sense to modify the crd/init.go to look at the existing CRD and patch `preserveUnknownFields` if set to true before applying the newly generated CRD definition? Maybe this is an option on the CRD customization?  (See PR https://github.com/rancher/wrangler/pull/158)

**Question:** do we need to add a WithPreserveUnknownFields(bool) helper so that users can alter whether it is true or false and let them shoot themselves in the foot if they are using defaults?

* Adds default struct tag parsing (thanks @ibuildthecloud)
* Sets XPreserveUnknownFields on all properties in the schema to `nil`