### PR TITLE
Revert condition formatting changes

### DIFF
--- a/pkg/summary/condition.go
+++ b/pkg/summary/condition.go
@@ -59,15 +59,7 @@ func (c Condition) Reason() string {
 }
 
 func (c Condition) Message() string {
-	m := c.String("message")
-	if m == "" {
-		res := c.Reason()
-		if res == "" {
-			return c.Type()
-		}
-		return c.Type() + " (" + res + ")"
-	}
-	return m
+	return c.String("message")
 }
 
 func (c Condition) Equals(other Condition) bool {


### PR DESCRIPTION
This partially reverts commit 3eba78f45e7d61364efd11d73334641c17305b4c.
This reverts commit 3533ace946aaf8cc64ae4be9ead3221c35975884.

The changes to the condition message formatting were not really helpful,
since the condition summary gets translated to a TransitioningMessage,
which does not always make sense when it shows up in the UI.

https://github.com/rancher/rancher/issues/32165