### PR TITLE
Add debug logging around webhook handler invocation

### DIFF
--- a/pkg/webhook/router.go
+++ b/pkg/webhook/router.go
@@ -74,13 +74,16 @@ func (r *Router) ServeHTTP(rw http.ResponseWriter, req *http.Request) {
 func (r *Router) admit(response *Response, request *v1.AdmissionRequest, req *http.Request) error {
 	for _, m := range r.matches {
 		if m.matches(request) {
-			return m.admit(response, &Request{
+			err := m.admit(response, &Request{
 				AdmissionRequest: *request,
 				Context:          req.Context(),
 				objTemplate:      m.getObjType(),
 			})
+			logrus.Debugf("admit result: %s %s %s user=%s allowed=%v err=%v", request.Operation, request.Kind.String(), resourceString(request.Namespace, request.Name), request.UserInfo.Username, response.Allowed, err)
+			return err
 		}
 	}
+	logrus.Debugf("no route match found for %s %s %s", request.Operation, request.Kind.String(), resourceString(request.Namespace, request.Name))
 	return nil
 }
 
@@ -141,4 +144,12 @@ type HandlerFunc func(resp *Response, req *Request) error
 
 func (h HandlerFunc) Admit(resp *Response, req *Request) error {
 	return h(resp, req)
+}
+
+// resourceString returns the resource formatted as a string
+func resourceString(ns, name string) string {
+	if ns == "" {
+		return name
+	}
+	return fmt.Sprintf("%s/%s", ns, name)
 }


### PR DESCRIPTION
These changes add access logs to webhook handlers with a middleware pattern. The logs have format that looks like:
```
DEBU[0003] CREATE management.cattle.io/v3.GlobalRole gr-wgmzb user=user-j9rfg allowed=false err=<nil> 
```
To enable, applications using the webhook package need to set logrus to the debug level