### PR TITLE
fix goroutine leaks, when using 'for range ticker.Context()' in gorou…

### DIFF
--- a/pkg/ticker/ticker.go
+++ b/pkg/ticker/ticker.go
@@ -7,9 +7,18 @@ import (
 
 func Context(ctx context.Context, duration time.Duration) <-chan time.Time {
 	ticker := time.NewTicker(duration)
+	c := make(chan time.Time)
 	go func() {
-		<-ctx.Done()
-		ticker.Stop()
+		for {
+			select {
+			case t := <-ticker.C:
+				c <- t
+			case <-ctx.Done():
+				close(c)
+				ticker.Stop()
+				return
+			}
+		}
 	}()
-	return ticker.C
+	return c
 }


### PR DESCRIPTION
"ticker.Context()" used in many places in the rancher,  like this "for range ticker.Context() {do something}", the channel will not be closed for "ticker.Stop()", "for range  ticker.Context() {do something}" outside the goroutine will never exit, cause goroutine leaks.