### PR TITLE
add ready state to summarizer

### DIFF
--- a/pkg/summary/summarizers.go
+++ b/pkg/summary/summarizers.go
@@ -86,6 +86,7 @@ var (
 	// Unknown == error
 	TransitioningFalse = map[string]string{
 		"Completed":           "activating",
+		"Ready":               "unavailable",
 		"Available":           "updating",
 		"BootstrapReady":      reason,
 		"InfrastructureReady": reason,


### PR DESCRIPTION
This was removed as a part of https://github.com/rancher/wrangler/commit/3eba78f45e7d61364efd11d73334641c17305b4c. Not sure if it was intentional, but this causes state to be Active for RKE1 nodes (and maybe clusters) even if the conditions have the right information. 

Issue: 
https://github.com/rancher/rancher/issues/32891