### PR TITLE
Better error handling and logging for webhook

### DIFF
--- a/pkg/webhook/router.go
+++ b/pkg/webhook/router.go
@@ -28,7 +28,7 @@ type Router struct {
 }
 
 func (r *Router) sendError(rw http.ResponseWriter, review *v1.AdmissionReview, err error) {
-	logrus.Debug(err)
+	logrus.Error(err)
 	if review == nil || review.Request == nil {
 		http.Error(rw, err.Error(), http.StatusInternalServerError)
 		return
@@ -83,8 +83,7 @@ func (r *Router) admit(response *Response, request *v1.AdmissionRequest, req *ht
 			return err
 		}
 	}
-	logrus.Debugf("no route match found for %s %s %s", request.Operation, request.Kind.String(), resourceString(request.Namespace, request.Name))
-	return nil
+	return fmt.Errorf("no route match found for %s %s %s", request.Operation, request.Kind.String(), resourceString(request.Namespace, request.Name))
 }
 
 func (r *Router) next() *RouteMatch {


### PR DESCRIPTION
Small improvement- returning error and also logging it at error level (if there is a situation where a request doesn't match any routes)

Example output: `ERRO[0025] no route match found for CREATE management.cattle.io/v3, Kind=GlobalRole gr-v9cg2 `