### PR TITLE
adding the RequestShutdown func from upstream

### DIFF
--- a/pkg/signals/signal.go
+++ b/pkg/signals/signal.go
@@ -1,12 +1,9 @@
 /*
 Copyright 2017 The Kubernetes Authors.
-
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
-
     http://www.apache.org/licenses/LICENSE-2.0
-
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,
 WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -23,22 +20,47 @@ import (
 )
 
 var onlyOneSignalHandler = make(chan struct{})
+var shutdownHandler chan os.Signal
 
 // SetupSignalHandler registered for SIGTERM and SIGINT. A stop channel is returned
 // which is closed on one of these signals. If a second signal is caught, the program
 // is terminated with exit code 1.
-func SetupSignalHandler(parent context.Context) context.Context {
-	close(onlyOneSignalHandler) // panics when called twice
-	ctx, cancel := context.WithCancel(parent)
+// Only one of SetupSignalContext and SetupSignalHandler should be called, and only can
+// be called once.
+func SetupSignalHandler() <-chan struct{} {
+	return SetupSignalContext().Done()
+}
 
-	c := make(chan os.Signal, 2)
-	signal.Notify(c, shutdownSignals...)
+// SetupSignalContext is same as SetupSignalHandler, but a context.Context is returned.
+// Only one of SetupSignalContext and SetupSignalHandler should be called, and only can
+// be called once.
+func SetupSignalContext() context.Context {
+	close(onlyOneSignalHandler) // panics when called twice
+
+	shutdownHandler = make(chan os.Signal, 2)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	signal.Notify(shutdownHandler, shutdownSignals...)
 	go func() {
-		<-c
+		<-shutdownHandler
 		cancel()
-		<-c
+		<-shutdownHandler
 		os.Exit(1) // second signal. Exit directly.
 	}()
 
 	return ctx
+}
+
+// RequestShutdown emulates a received event that is considered as shutdown signal (SIGTERM/SIGINT)
+// This returns whether a handler was notified
+func RequestShutdown() bool {
+	if shutdownHandler != nil {
+		select {
+		case shutdownHandler <- shutdownSignals[0]:
+			return true
+		default:
+		}
+	}
+
+	return false
 }


### PR DESCRIPTION
trying to get this shutdown func to use from windows service manager to cancel context when a service is stopped via Stop-Service in powershell.

source: https://github.com/kubernetes/kubernetes/blob/da707b6133ff0c66dc4d24295374e7e5de8852f5/staging/src/k8s.io/apiserver/pkg/server/signal.go#L59-L69

example usage: https://github.com/kubernetes/kubernetes/blob/da707b6133ff0c66dc4d24295374e7e5de8852f5/pkg/windows/service/service.go#L82-L87