### PR TITLE
fixed permissions errors when applying multiple namespaces

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/rancher/wrangler
 
-go 1.13
+go 1.16
 
 require (
 	github.com/evanphx/json-patch v4.5.0+incompatible
@@ -14,6 +14,7 @@ require (
 	github.com/pkg/errors v0.9.1
 	github.com/rancher/lasso v0.0.0-20210616224652-fc3ebd901c08
 	github.com/sirupsen/logrus v1.4.2
+	github.com/stretchr/testify v1.7.0 // indirect
 	golang.org/x/crypto v0.0.0-20210322153248-0c34fe9e7dc2
 	golang.org/x/sync v0.0.0-20190911185100-cd5d95a43a6e
 	golang.org/x/tools v0.0.0-20191017205301-920acffc3e65

--- a/go.sum
+++ b/go.sum
@@ -347,6 +347,8 @@ github.com/stretchr/testify v1.2.3-0.20181224173747-660f15d67dbb/go.mod h1:a8OnR
 github.com/stretchr/testify v1.3.0/go.mod h1:M5WIy9Dh21IEIfnGCwXGc5bZfKNJtfHm1UVUgZn+9EI=
 github.com/stretchr/testify v1.4.0 h1:2E4SXV/wtOkTonXsotYi4li6zVWxYlZuYNCXe9XRJyk=
 github.com/stretchr/testify v1.4.0/go.mod h1:j7eGeouHqKxXV5pUuKE4zz7dFj8WfuZ+81PSLYec5m4=
+github.com/stretchr/testify v1.7.0 h1:nwc3DEeHmmLAfoZucVR881uASk0Mfjw8xYJ99tb5CcY=
+github.com/stretchr/testify v1.7.0/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
 github.com/tidwall/pretty v1.0.0/go.mod h1:XNkn88O1ChpSDQmQeStsy+sBenx6DDtFZJxhVysOjyk=
 github.com/tmc/grpc-websocket-proxy v0.0.0-20170815181823-89b8d40f7ca8/go.mod h1:ncp9v5uamzpCO7NfCPTXjqaC+bZgJeR0sMTm6dMHP7U=
 github.com/tmc/grpc-websocket-proxy v0.0.0-20190109142713-0ad062ec5ee5/go.mod h1:ncp9v5uamzpCO7NfCPTXjqaC+bZgJeR0sMTm6dMHP7U=
@@ -537,6 +539,8 @@ gopkg.in/yaml.v2 v2.3.0 h1:clyUAQHOM3G0M3f5vQj7LuJrETvjVot3Z5el9nffUtU=
 gopkg.in/yaml.v2 v2.3.0/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=
 gopkg.in/yaml.v3 v3.0.0-20191120175047-4206685974f2/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=
 gopkg.in/yaml.v3 v3.0.0-20200121175148-a6ecf24a6d71/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=
+gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c h1:dUUwHk2QECo/6vqA44rthZ8ie2QXMNeKRTHCNY2nXvo=
+gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=
 gotest.tools v2.2.0+incompatible/go.mod h1:DsYFclhRJ6vuDpmuTbkuFWG+y2sxOXAzmJt81HFBacw=
 honnef.co/go/tools v0.0.0-20190102054323-c2f93a96b099/go.mod h1:rf3lG4BRIbNafJWhAfAdb/ePZxsR/4RtNHQocxwk9r4=
 honnef.co/go/tools v0.0.0-20190106161140-3f1c8253044a/go.mod h1:rf3lG4BRIbNafJWhAfAdb/ePZxsR/4RtNHQocxwk9r4=

--- a/pkg/apply/desiredset_process_test.go
+++ b/pkg/apply/desiredset_process_test.go
@@ -1,0 +1,108 @@
+package apply
+
+import (
+	"context"
+	"errors"
+	"github.com/stretchr/testify/assert"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/labels"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/client-go/dynamic/fake"
+	k8stesting "k8s.io/client-go/testing"
+	"strings"
+	"testing"
+)
+
+func Test_multiNamespaceList(t *testing.T) {
+	results := map[string]*unstructured.UnstructuredList{
+		"ns1": {Items: []unstructured.Unstructured{
+			{Object: map[string]interface{}{"name": "o1", "namespace": "ns1"}},
+			{Object: map[string]interface{}{"name": "o2", "namespace": "ns1"}},
+			{Object: map[string]interface{}{"name": "o3", "namespace": "ns1"}},
+		}},
+		"ns2": {Items: []unstructured.Unstructured{
+			{Object: map[string]interface{}{"name": "o4", "namespace": "ns2"}},
+			{Object: map[string]interface{}{"name": "o5", "namespace": "ns2"}},
+		}},
+		"ns3": {Items: []unstructured.Unstructured{}},
+	}
+
+	baseClient := fake.NewSimpleDynamicClient(runtime.NewScheme())
+	baseClient.PrependReactor("list", "*", func(action k8stesting.Action) (handled bool, ret runtime.Object, err error) {
+		if strings.Contains(action.GetNamespace(), "error") {
+			return true, nil, errors.New("simulated failure")
+		}
+
+		return true, results[action.GetNamespace()], nil
+	})
+
+	type args struct {
+		namespaces []string
+	}
+	tests := []struct {
+		name          string
+		args          args
+		expectedCalls int
+		expectError   bool
+	}{
+		{
+			name: "no namespaces",
+			args: args{
+				namespaces: []string{},
+			},
+			expectError:   false,
+			expectedCalls: 0,
+		},
+		{
+			name: "1 namespace",
+			args: args{
+				namespaces: []string{"ns1"},
+			},
+			expectError:   false,
+			expectedCalls: 3,
+		},
+		{
+			name: "many namespaces",
+			args: args{
+				namespaces: []string{"ns1", "ns2", "ns3"},
+			},
+			expectError:   false,
+			expectedCalls: 5,
+		},
+		{
+			name: "1 namespace error",
+			args: args{
+				namespaces: []string{"error", "ns2", "ns3"},
+			},
+			expectError:   true,
+			expectedCalls: -1,
+		},
+		{
+			name: "many namespace errors",
+			args: args{
+				namespaces: []string{"error", "error1", "error2"},
+			},
+			expectError:   true,
+			expectedCalls: -1,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var calls int
+			err := multiNamespaceList(context.TODO(), tt.args.namespaces, baseClient.Resource(schema.GroupVersionResource{}), labels.NewSelector(), func(obj unstructured.Unstructured) {
+				calls += 1
+			})
+
+			if tt.expectError {
+				assert.Error(t, err)
+			} else {
+				assert.NoError(t, err)
+			}
+
+			if tt.expectedCalls >= 0 {
+				assert.Equal(t, tt.expectedCalls, calls)
+			}
+		})
+	}
+}

--- a/pkg/objectset/objectset.go
+++ b/pkg/objectset/objectset.go
@@ -167,6 +167,31 @@ func (o *ObjectSet) GVKOrder(known ...schema.GroupVersionKind) []schema.GroupVer
 	return append(o.gvkOrder, rest...)
 }
 
+// Namespaces all distinct namespaces found on the objects in this set.
+func (o *ObjectSet) Namespaces() (namespaces []string) {
+	for _, objsByKey := range o.ObjectsByGVK() {
+		for objKey, _ := range objsByKey {
+
+			// do not add duplicate namespace entries
+			var duplicate bool
+			for i := range namespaces {
+				if namespaces[i] == objKey.Namespace {
+					duplicate = true
+					break
+				}
+			}
+
+			if duplicate {
+				continue
+			}
+
+			namespaces = append(namespaces, objKey.Namespace)
+		}
+	}
+
+	return
+}
+
 type ObjectByGK map[schema.GroupKind]map[ObjectKey]runtime.Object
 
 func (o ObjectByGK) Add(obj runtime.Object) (schema.GroupKind, error) {

--- a/pkg/objectset/objectset_test.go
+++ b/pkg/objectset/objectset_test.go
@@ -1,0 +1,84 @@
+package objectset
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+)
+
+func TestObjectSet_Namespaces(t *testing.T) {
+	type fields struct {
+		errs        []error
+		objects     ObjectByGVK
+		objectsByGK ObjectByGK
+		order       []runtime.Object
+		gvkOrder    []schema.GroupVersionKind
+		gvkSeen     map[schema.GroupVersionKind]bool
+	}
+	tests := []struct {
+		name           string
+		fields         fields
+		wantNamespaces []string
+	}{
+		{
+			name: "empty",
+			fields: fields{
+				objects: map[schema.GroupVersionKind]map[ObjectKey]runtime.Object{},
+			},
+			wantNamespaces: nil,
+		},
+		{
+			name: "1 namespace",
+			fields: fields{
+				objects: map[schema.GroupVersionKind]map[ObjectKey]runtime.Object{
+					schema.GroupVersionKind{}: {
+						ObjectKey{Namespace: "ns1", Name: "a"}: nil,
+						ObjectKey{Namespace: "ns1", Name: "b"}: nil,
+					},
+				},
+			},
+			wantNamespaces: []string{"ns1"},
+		},
+		{
+			name: "many namespace",
+			fields: fields{
+				objects: map[schema.GroupVersionKind]map[ObjectKey]runtime.Object{
+					schema.GroupVersionKind{}: {
+						ObjectKey{Namespace: "ns1", Name: "a"}: nil,
+						ObjectKey{Namespace: "ns2", Name: "b"}: nil,
+					},
+				},
+			},
+			wantNamespaces: []string{"ns1", "ns2"},
+		},
+		{
+			name: "missing namespace",
+			fields: fields{
+				objects: map[schema.GroupVersionKind]map[ObjectKey]runtime.Object{
+					schema.GroupVersionKind{}: {
+						ObjectKey{Namespace: "ns1", Name: "a"}: nil,
+						ObjectKey{Name: "b"}:                   nil,
+					},
+				},
+			},
+			wantNamespaces: []string{"", "ns1"},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			o := &ObjectSet{
+				errs:        tt.fields.errs,
+				objects:     tt.fields.objects,
+				objectsByGK: tt.fields.objectsByGK,
+				order:       tt.fields.order,
+				gvkOrder:    tt.fields.gvkOrder,
+				gvkSeen:     tt.fields.gvkSeen,
+			}
+
+			gotNamespaces := o.Namespaces()
+			assert.ElementsMatchf(t, tt.wantNamespaces, gotNamespaces, "Namespaces() = %v, want %v", gotNamespaces, tt.wantNamespaces)
+		})
+	}
+}


### PR DESCRIPTION
https://github.com/rancher/rancher/issues/34712

# Problem
When users try  to modify resources in multiple namespaces wrangler attempts to list them across all namespaces.  Most users do not have permission to list resources across all namespaces and an error is returned.

# Solution
When applying resources gather what namespaces will be affected make multiple searches across the specified namespaces.

# Testing
I tested this and confirmed users will still see permission errors if they attempt to create a resource in a namespace that they do not have access to.  I also  tested creating resources that are not namespaced with a user that has access to them.