### PR TITLE
fix: TrimRight removes an extra character in certain conditions

### DIFF
--- a/pkg/controller-gen/generators/client_generator.go
+++ b/pkg/controller-gen/generators/client_generator.go
@@ -74,7 +74,7 @@ func (cg *ClientGenerator) Packages(context *generator.Context, arguments *args.
 }
 
 func (cg *ClientGenerator) typesGroupPackage(name *types.Name, gv schema.GroupVersion, generatorArgs *args.GeneratorArgs, customArgs *args2.CustomArgs) generator.Package {
-	packagePath := strings.TrimRight(name.Package, "/"+gv.Version)
+	packagePath := strings.TrimSuffix(name.Package, "/"+gv.Version)
 	return Package(generatorArgs, packagePath, func(context *generator.Context) []generator.Generator {
 		return []generator.Generator{
 			RegisterGroupGo(gv.Group, generatorArgs, customArgs),


### PR DESCRIPTION
TrimRight isn't the right function to use here, in fact it can cause all sorts of unwanted behavior because the cutset is going to be something like `/v1` or `/v1beta1` and TrimRight will remove any of the characters regardless of order (at least how I understand it) from the right if they exist. 

We actually only want to TrimSuffix when it specifically matches `/+gv.Version` so `/v1` or `/v1beta1` etc.

I was using `project.ekristen.dev` when this code was generating `project.ekristen.de` because it was Trimming right `/v1` from `project.ekristen.dev/v1` so it was removing extra v because the cutset is `/v1`

