### PR TITLE
Fixed distinct namespaces resolution in Apply

### DIFF
--- a/pkg/apply/desiredset_process_test.go
+++ b/pkg/apply/desiredset_process_test.go
@@ -3,6 +3,10 @@ package apply
 import (
 	"context"
 	"errors"
+	"strings"
+	"testing"
+
+	"github.com/rancher/wrangler/pkg/objectset"
 	"github.com/stretchr/testify/assert"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/labels"
@@ -10,8 +14,6 @@ import (
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/client-go/dynamic/fake"
 	k8stesting "k8s.io/client-go/testing"
-	"strings"
-	"testing"
 )
 
 func Test_multiNamespaceList(t *testing.T) {
@@ -103,6 +105,59 @@ func Test_multiNamespaceList(t *testing.T) {
 			if tt.expectedCalls >= 0 {
 				assert.Equal(t, tt.expectedCalls, calls)
 			}
+		})
+	}
+}
+
+func TestObjectSet_getDistinctNamespaces(t *testing.T) {
+	tests := []struct {
+		name           string
+		objects        map[objectset.ObjectKey]runtime.Object
+		wantNamespaces []string
+	}{
+		{
+			name:           "empty",
+			objects:        map[objectset.ObjectKey]runtime.Object{},
+			wantNamespaces: nil,
+		},
+		{
+			name: "1 namespace",
+			objects: map[objectset.ObjectKey]runtime.Object{
+				objectset.ObjectKey{Namespace: "ns1", Name: "a"}: nil,
+				objectset.ObjectKey{Namespace: "ns1", Name: "b"}: nil,
+			},
+			wantNamespaces: []string{"ns1"},
+		},
+		{
+			name: "many namespaces",
+			objects: map[objectset.ObjectKey]runtime.Object{
+				objectset.ObjectKey{Namespace: "ns1", Name: "a"}: nil,
+				objectset.ObjectKey{Namespace: "ns2", Name: "b"}: nil,
+			},
+			wantNamespaces: []string{"ns1", "ns2"},
+		},
+		{
+			name: "many namespaces with duplicates",
+			objects: map[objectset.ObjectKey]runtime.Object{
+				objectset.ObjectKey{Namespace: "ns1", Name: "a"}: nil,
+				objectset.ObjectKey{Namespace: "ns2", Name: "b"}: nil,
+				objectset.ObjectKey{Namespace: "ns1", Name: "c"}: nil,
+			},
+			wantNamespaces: []string{"ns1", "ns2"},
+		},
+		{
+			name: "missing namespace",
+			objects: map[objectset.ObjectKey]runtime.Object{
+				objectset.ObjectKey{Namespace: "ns1", Name: "a"}: nil,
+				objectset.ObjectKey{Name: "b"}:                   nil,
+			},
+			wantNamespaces: []string{"", "ns1"},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			gotNamespaces := getDistinctNamespaces(tt.objects)
+			assert.ElementsMatchf(t, tt.wantNamespaces, gotNamespaces, "getDistinctNamespaces() = %v, want %v", gotNamespaces, tt.wantNamespaces)
 		})
 	}
 }


### PR DESCRIPTION
https://github.com/rancher/rancher/issues/35656

The issue is caused by https://github.com/rancher/wrangler/pull/183 resolving distinct namespaces based on objects from all GVKs included into apply manifest instead of objects of GVK being processed in the current `process` iteration. The PR addresses this issue.

Note the linked PR implemented `ObjectSet.Namespaces` which is no longer needed. However, decided to leave it in since it's exported function of a library that made it into a release and it has good test coverage - there is a chance it will be useful for something else.