### PR TITLE
Remove empty strings from summary messages

### DIFF
--- a/pkg/summary/summary.go
+++ b/pkg/summary/summary.go
@@ -67,10 +67,6 @@ func (s *Summary) DeepCopyInto(v *Summary) {
 }
 
 func dedupMessage(messages []string) []string {
-	if len(messages) <= 1 {
-		return messages
-	}
-
 	seen := map[string]bool{}
 	var result []string
 


### PR DESCRIPTION
If a summary message had two or more empty strings, then they would all be
removed on deduplication. After this change, if a summary message has a single
empty string, then that empty string is also removed.