### PR TITLE
fix: generated controller status handler with custom condition

### DIFF
--- a/pkg/controller-gen/generators/type_go.go
+++ b/pkg/controller-gen/generators/type_go.go
@@ -360,7 +360,7 @@ func (a *{{.lowerName}}StatusHandler) sync(key string, obj *{{.version}}.{{.type
 		newStatus = *origStatus.DeepCopy()
 	}
 
-	if a.condition != "" {
+	if a.condition != "" && err != nil {
 		if errors.IsConflict(err) {
 			a.condition.SetError(&newStatus, "", nil)
 		} else {


### PR DESCRIPTION
This fixes an issue with wrangler that if you are using a defined `cond.Condition` with a StatusHandler the SetStatus, Message, and SetReason and more from working.

It might not be limited to the cond.Condition usage but basically a.Condition != "" should not be triggered unless there is also an err, this adds a check for err as well.