### PR TITLE
add checks for uint and uintptr when inspecting schema fields

### DIFF
--- a/pkg/schemas/reflection.go
+++ b/pkg/schemas/reflection.go
@@ -269,6 +269,8 @@ func (s *Schemas) readFields(schema *Schema, t reflect.Type) error {
 		} else if fieldType.Kind() == reflect.Bool {
 			schemaField.Nullable = false
 		} else if fieldType.Kind() == reflect.Int ||
+			fieldType.Kind() == reflect.Uint ||
+			fieldType.Kind() == reflect.Uintptr ||
 			fieldType.Kind() == reflect.Uint32 ||
 			fieldType.Kind() == reflect.Int32 ||
 			fieldType.Kind() == reflect.Uint64 ||
@@ -472,6 +474,10 @@ func (s *Schemas) determineSchemaType(t reflect.Type) (string, error) {
 	case reflect.Int:
 		fallthrough
 	case reflect.Int32:
+		fallthrough
+	case reflect.Uint:
+		fallthrough
+	case reflect.Uintptr:
 		fallthrough
 	case reflect.Uint32:
 		fallthrough

--- a/pkg/schemas/reflection.go
+++ b/pkg/schemas/reflection.go
@@ -471,23 +471,9 @@ func (s *Schemas) determineSchemaType(t reflect.Type) (string, error) {
 		return "byte", nil
 	case reflect.Bool:
 		return "boolean", nil
-	case reflect.Int:
-		fallthrough
-	case reflect.Int32:
-		fallthrough
-	case reflect.Uint:
-		fallthrough
-	case reflect.Uintptr:
-		fallthrough
-	case reflect.Uint32:
-		fallthrough
-	case reflect.Uint64:
-		fallthrough
-	case reflect.Int64:
+	case reflect.Int, reflect.Int32, reflect.Uint, reflect.Uintptr, reflect.Uint32, reflect.Uint64, reflect.Int64:
 		return "int", nil
-	case reflect.Float32:
-		fallthrough
-	case reflect.Float64:
+	case reflect.Float32, reflect.Float64:
 		return "float", nil
 	case reflect.Interface:
 		return "json", nil


### PR DESCRIPTION
 Fixes harvester [issue 1919](https://github.com/harvester/harvester/issues/1919)

Add type checks for omitted but reasonably likely to be used types `uint` and `uintptr` during field type inspection.