### PR TITLE
Add Reconciled condition to TransitioningUnknown

### DIFF
--- a/pkg/summary/summarizers.go
+++ b/pkg/summary/summarizers.go
@@ -45,6 +45,7 @@ var (
 		"Pending":                     "pending",
 		"PodScheduled":                "scheduling",
 		"Provisioned":                 "provisioning",
+		"Reconciled":                  "reconciling",
 		"Refreshed":                   "refreshed",
 		"Registered":                  "registering",
 		"Removed":                     "removing",


### PR DESCRIPTION
Related issue: https://github.com/rancher/rancher/issues/36993

In order to make a better and more consistent experience in Rancher's
UI, some objects will now go into a Reconciled unknown state. In order
for this to showup properly in the UI, this condition needs to be added
to the list of TransitioningUnknown conditions. This change does exactly
that.