### PR TITLE
Fix job reconciler diff

### DIFF
--- a/pkg/apply/apply.go
+++ b/pkg/apply/apply.go
@@ -23,7 +23,7 @@ const (
 type Patcher func(namespace, name string, pt types.PatchType, data []byte) (runtime.Object, error)
 
 // return false if the Reconciler did not handler this object
-type Reconciler func(oldObj runtime.Object, newObj runtime.Object) (bool, error)
+type Reconciler func(oldObj runtime.Object, newObjPruned, newObj runtime.Object) (bool, error)
 
 type ClientFactory func(gvr schema.GroupVersionResource) (dynamic.NamespaceableResourceInterface, error)
 

--- a/pkg/apply/desiredset_compare.go
+++ b/pkg/apply/desiredset_compare.go
@@ -213,6 +213,14 @@ func applyPatch(gvk schema.GroupVersionKind, reconciler Reconciler, patcher Patc
 		if err != nil {
 			return false, err
 		}
+
+		// We round trip the object here because when serializing to the applied
+		// annotation values are truncated to 64 bytes.
+		newObjectPruned, err := getOriginalObject(gvk, newObject.(v1.Object))
+		if err != nil {
+			return false, err
+		}
+
 		originalObject, err := getOriginalObject(gvk, oldMetadata)
 		if err != nil {
 			return false, err
@@ -220,7 +228,7 @@ func applyPatch(gvk schema.GroupVersionKind, reconciler Reconciler, patcher Patc
 		if originalObject == nil {
 			originalObject = oldObject
 		}
-		handled, err := reconciler(originalObject, newObject)
+		handled, err := reconciler(originalObject, newObjectPruned, newObject)
 		if err != nil {
 			return false, err
 		}

--- a/pkg/apply/reconcilers.go
+++ b/pkg/apply/reconcilers.go
@@ -24,7 +24,7 @@ var (
 	}
 )
 
-func reconcileDaemonSet(oldObj, newObj runtime.Object) (bool, error) {
+func reconcileDaemonSet(oldObj, _, newObj runtime.Object) (bool, error) {
 	oldSvc, ok := oldObj.(*appsv1.DaemonSet)
 	if !ok {
 		oldSvc = &appsv1.DaemonSet{}
@@ -47,7 +47,7 @@ func reconcileDaemonSet(oldObj, newObj runtime.Object) (bool, error) {
 	return false, nil
 }
 
-func reconcileDeployment(oldObj, newObj runtime.Object) (bool, error) {
+func reconcileDeployment(oldObj, _, newObj runtime.Object) (bool, error) {
 	oldSvc, ok := oldObj.(*appsv1.Deployment)
 	if !ok {
 		oldSvc = &appsv1.Deployment{}
@@ -70,7 +70,7 @@ func reconcileDeployment(oldObj, newObj runtime.Object) (bool, error) {
 	return false, nil
 }
 
-func reconcileSecret(oldObj, newObj runtime.Object) (bool, error) {
+func reconcileSecret(oldObj, _, newObj runtime.Object) (bool, error) {
 	oldSvc, ok := oldObj.(*v1.Secret)
 	if !ok {
 		oldSvc = &v1.Secret{}
@@ -93,7 +93,7 @@ func reconcileSecret(oldObj, newObj runtime.Object) (bool, error) {
 	return false, nil
 }
 
-func reconcileService(oldObj, newObj runtime.Object) (bool, error) {
+func reconcileService(oldObj, _, newObj runtime.Object) (bool, error) {
 	oldSvc, ok := oldObj.(*v1.Service)
 	if !ok {
 		oldSvc = &v1.Service{}
@@ -116,7 +116,7 @@ func reconcileService(oldObj, newObj runtime.Object) (bool, error) {
 	return false, nil
 }
 
-func reconcileJob(oldObj, newObj runtime.Object) (bool, error) {
+func reconcileJob(oldObj, newObj, _ runtime.Object) (bool, error) {
 	oldSvc, ok := oldObj.(*batchv1.Job)
 	if !ok {
 		oldSvc = &batchv1.Job{}


### PR DESCRIPTION
For reconcilers the originalObject that was passed is built from the the applied annotation.  That object will have all string values truncated to 64 bytes.  The job reconciler would fail because it does a full object compare and if any desired value was greater that 64 bytes it would never match because the originalObject's >64 byte value would be truncated.

To resolve this we now pass the newObject to be created and all the newObject truncated so that an exact comparsion can be done against the originalObject.
