### PR TITLE
fix truncated job annotations

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/rancher/wrangler
 
-go 1.16
+go 1.17
 
 require (
 	github.com/evanphx/json-patch v4.12.0+incompatible

--- a/pkg/apply/apply.go
+++ b/pkg/apply/apply.go
@@ -22,7 +22,7 @@ const (
 
 type Patcher func(namespace, name string, pt types.PatchType, data []byte) (runtime.Object, error)
 
-// return false if the Reconciler did not handler this object
+// Reconciler return false if it did not handle this object
 type Reconciler func(oldObj runtime.Object, newObj runtime.Object) (bool, error)
 
 type ClientFactory func(gvr schema.GroupVersionResource) (dynamic.NamespaceableResourceInterface, error)


### PR DESCRIPTION
update reconciler for job to get a new pruned obj back to avoid 64 byte truncated annotations