### PR TITLE
Adds webhook documentation and makes Request fully public.

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,6 @@ Wrangler is a framework for using controllers. Controllers wrap clients, informe
 	2. [How to Run Handlers](#how-to-run-handlers)
 	3. [Different Ways of Interacting with Objects](#different-ways-of-interacting-with-objects)
 	4. [A Look at Structures Used in Wrangler](#a-look-at-structures-used-in-wrangler)
-3. [Documentation TODO](#documentation-todo)
 
 <br>
 
@@ -319,7 +318,7 @@ type FooClient interface {
 	// Update updates the given object in kubernetes
 	Update(*v1alpha1.Foo) (*v1alpha1.Foo, error)
 	// Status of type's CRD must be a subresource for this method to be generated. Only updates
-	// status and does not trigger OnChange handlers. TODO: confirm this.
+	// status and does not trigger OnChange handlers.
 	UpdateStatus(*v1alpha1.Foo) (*v1alpha1.Foo, error)
 	// Delete deletes the given object in kubernetes
 	Delete(namespace, name string, options *metav1.DeleteOptions) error

--- a/pkg/webhook/match.go
+++ b/pkg/webhook/match.go
@@ -5,6 +5,7 @@ import (
 	"k8s.io/apimachinery/pkg/runtime"
 )
 
+// RouteMatch type matching of admission Request to Handlers.
 type RouteMatch struct {
 	handler     Handler
 	kind        string
@@ -27,9 +28,8 @@ func (r *RouteMatch) admit(response *Response, request *Request) error {
 }
 
 func (r *RouteMatch) matches(req *v1.AdmissionRequest) bool {
-	var (
-		group, version, kind, resource string
-	)
+	var group, version, kind, resource string
+
 	if req.RequestKind != nil {
 		group, version, kind = req.RequestKind.Group, req.RequestKind.Version, req.RequestKind.Kind
 	}
@@ -74,32 +74,78 @@ func checkBool(expected, actual *bool) bool {
 
 // Pretty methods
 
-func (r *RouteMatch) DryRun(dryRun bool) *RouteMatch               { r.dryRun = &dryRun; return r }
-func (r *RouteMatch) Group(group string) *RouteMatch               { r.group = group; return r }
-func (r *RouteMatch) HandleFunc(handler HandlerFunc) *RouteMatch   { r.handler = handler; return r }
-func (r *RouteMatch) Handle(handler Handler) *RouteMatch           { r.handler = handler; return r }
-func (r *RouteMatch) Kind(kind string) *RouteMatch                 { r.kind = kind; return r }
-func (r *RouteMatch) Name(name string) *RouteMatch                 { r.name = name; return r }
-func (r *RouteMatch) Namespace(namespace string) *RouteMatch       { r.namespace = namespace; return r }
+// DryRun matches admission request with the matching DryRun value.
+func (r *RouteMatch) DryRun(dryRun bool) *RouteMatch { r.dryRun = &dryRun; return r }
+
+// Group matches admission request with the matching Group value.
+func (r *RouteMatch) Group(group string) *RouteMatch { r.group = group; return r }
+
+// HandleFunc sets the handler to be called for matching admission request.
+func (r *RouteMatch) HandleFunc(handler HandlerFunc) *RouteMatch { r.handler = handler; return r }
+
+// Handle sets the Handler to be called for matching admission request.
+func (r *RouteMatch) Handle(handler Handler) *RouteMatch { r.handler = handler; return r }
+
+// Kind matches admission request with the matching Kind value.
+func (r *RouteMatch) Kind(kind string) *RouteMatch { r.kind = kind; return r }
+
+// Name matches admission request with the matching Name value.
+func (r *RouteMatch) Name(name string) *RouteMatch { r.name = name; return r }
+
+// Namespace matches admission request with the matching Namespace value.
+func (r *RouteMatch) Namespace(namespace string) *RouteMatch { r.namespace = namespace; return r }
+
+// Operation matches admission request with the matching Operation value.
 func (r *RouteMatch) Operation(operation v1.Operation) *RouteMatch { r.operation = operation; return r }
-func (r *RouteMatch) Resource(resource string) *RouteMatch         { r.resource = resource; return r }
-func (r *RouteMatch) SubResource(sr string) *RouteMatch            { r.subResource = sr; return r }
-func (r *RouteMatch) Type(objType runtime.Object) *RouteMatch      { r.objType = objType; return r }
-func (r *RouteMatch) Version(version string) *RouteMatch           { r.version = version; return r }
+
+// Resource matches admission request with the matching Resource value.
+func (r *RouteMatch) Resource(resource string) *RouteMatch { r.resource = resource; return r }
+
+// SubResource matches admission request with the matching SubResource value.
+func (r *RouteMatch) SubResource(sr string) *RouteMatch { r.subResource = sr; return r }
+
+// Type specifies the runtime.Object to use for decoding.
+func (r *RouteMatch) Type(objType runtime.Object) *RouteMatch { r.objType = objType; return r }
+
+// Version matches admission request with the matching Version value.
+func (r *RouteMatch) Version(version string) *RouteMatch { r.version = version; return r }
 
 // Wrappers for pretty methods
 
-func (r *Router) DryRun(dryRun bool) *RouteMatch               { return r.next().DryRun(dryRun) }
-func (r *Router) Group(group string) *RouteMatch               { return r.next().Group(group) }
-func (r *Router) HandleFunc(hf HandlerFunc) *RouteMatch        { return r.next().HandleFunc(hf) }
-func (r *Router) Handle(handler Handler) *RouteMatch           { return r.next().Handle(handler) }
-func (r *Router) Kind(kind string) *RouteMatch                 { return r.next().Kind(kind) }
-func (r *Router) Name(name string) *RouteMatch                 { return r.next().Name(name) }
-func (r *Router) Namespace(namespace string) *RouteMatch       { return r.next().Namespace(namespace) }
+// DryRun matches admission request with the matching DryRun value.
+func (r *Router) DryRun(dryRun bool) *RouteMatch { return r.next().DryRun(dryRun) }
+
+// Group matches admission request with the matching Group value.
+func (r *Router) Group(group string) *RouteMatch { return r.next().Group(group) }
+
+// HandleFunc sets the handler to be called for matching admission request.
+func (r *Router) HandleFunc(hf HandlerFunc) *RouteMatch { return r.next().HandleFunc(hf) }
+
+// Handle sets the Handler to be called for matching admission request.
+func (r *Router) Handle(handler Handler) *RouteMatch { return r.next().Handle(handler) }
+
+// Kind matches admission request with the matching Kind value.
+func (r *Router) Kind(kind string) *RouteMatch { return r.next().Kind(kind) }
+
+// Name matches admission request with the matching Name value.
+func (r *Router) Name(name string) *RouteMatch { return r.next().Name(name) }
+
+// Namespace matches admission request with the matching Namespace value.
+func (r *Router) Namespace(namespace string) *RouteMatch { return r.next().Namespace(namespace) }
+
+// Operation matches admission request with the matching Operation value.
 func (r *Router) Operation(operation v1.Operation) *RouteMatch { return r.next().Operation(operation) }
-func (r *Router) Resource(resource string) *RouteMatch         { return r.next().Resource(resource) }
+
+// Resource matches admission request with the matching Resource value.
+func (r *Router) Resource(resource string) *RouteMatch { return r.next().Resource(resource) }
+
+// SubResource matches admission request with the matching SubResource value.
 func (r *Router) SubResource(subResource string) *RouteMatch {
 	return r.next().SubResource(subResource)
 }
+
+// Type specifies the runtime.Object to use for decoding.
 func (r *Router) Type(objType runtime.Object) *RouteMatch { return r.next().Type(objType) }
-func (r *Router) Version(version string) *RouteMatch      { return r.next().Version(version) }
+
+// Version matches admission request with the matching Version value.
+func (r *Router) Version(version string) *RouteMatch { return r.next().Version(version) }


### PR DESCRIPTION
To create effective tests in supported projects, callers need
the ability to create a valid webhook.Request which involves
setting the ObjectType.