### PR TITLE
Leader election: do not wait 2 hours for retry, even in dev mode

### DIFF
--- a/pkg/leader/leader.go
+++ b/pkg/leader/leader.go
@@ -52,7 +52,7 @@ func run(ctx context.Context, namespace, name string, client kubernetes.Interfac
 		Lock:          rl,
 		LeaseDuration: 45 * t,
 		RenewDeadline: 30 * t,
-		RetryPeriod:   2 * t,
+		RetryPeriod:   2 * time.Second,
 		Callbacks: leaderelection.LeaderCallbacks{
 			OnStartedLeading: func(ctx context.Context) {
 				go cb(ctx)


### PR DESCRIPTION
I found it useful to leverage the `CATTLE_DEV_MODE` environment variable in order to make leader leases last longer - this is pretty much needed when attaching a debugger (eg. [via delve](https://github.com/moio/delve-debugger)) - else the process is automatically killed after some seconds.

Problem with `CATTLE_DEV_MODE` in that scenario is, at the moment, that it also elongates the retry period, which means the initial leader election at process start will also take two hours, which is a bit impractical.

This PR tries to address the issue by elongating all times but the retry period - I tested it manually and it works great for delve debugging.

Related: #234 
Issue: https://github.com/rancher/rancher/issues/39506
