### PR TITLE
[EXPERIMENTAL] Optimize Apply when WithIgnorePreviousApplied is specified

### DIFF
--- a/pkg/apply/desiredset_compare.go
+++ b/pkg/apply/desiredset_compare.go
@@ -170,17 +170,18 @@ func applyPatch(gvk schema.GroupVersionKind, reconciler Reconciler, patcher Patc
 		return false, err
 	}
 
-	original, err := getOriginalBytes(gvk, oldMetadata)
-	if err != nil {
-		return false, err
+	var original []byte
+
+	if !ignoreOriginal {
+		original, err = getOriginalBytes(gvk, oldMetadata)
+		if err != nil {
+			return false, err
+		}
 	}
+
 	modified, err := getModified(gvk, newObject)
 	if err != nil {
 		return false, err
-	}
-
-	if ignoreOriginal {
-		original = nil
 	}
 
 	current, err := json.Marshal(oldObject)

--- a/pkg/apply/desiredset_process.go
+++ b/pkg/apply/desiredset_process.go
@@ -284,7 +284,7 @@ func (o *desiredSet) process(debugID string, set labels.Selector, gvk schema.Gro
 
 	createF := func(k objectset.ObjectKey) {
 		obj := objs[k]
-		obj, err := prepareObjectForCreate(gvk, obj)
+		obj, err := prepareObjectForCreate(gvk, obj, o.ignorePreviousApplied)
 		if err != nil {
 			o.err(errors.Wrapf(err, "failed to prepare create %s %s for %s", k, gvk, debugID))
 			return


### PR DESCRIPTION
The `IgnorePreviousApplied` (aka `ignoreOriginal`) Apply option avoids the standard `kubectl apply`-inspired 3-way patching algorithm in favor of a simpler 2-way patch that ignores previous applications of the same object.

This patchset aims to avoid superfluous operations when this option is set while not introducing regressions.

This patchset is being tested by fleet users and will be finalized when there is conclusive evidence it actually helps with performance. I will remove the `[EXPERIMENTAL]` title at that point.

This patchset is best reviewed commit-by-commit.