### PR TITLE
Update webhook matching

### DIFF
--- a/pkg/webhook/match.go
+++ b/pkg/webhook/match.go
@@ -28,20 +28,11 @@ func (r *RouteMatch) admit(response *Response, request *Request) error {
 }
 
 func (r *RouteMatch) matches(req *v1.AdmissionRequest) bool {
-	var group, version, kind, resource string
-
-	if req.RequestKind != nil {
-		group, version, kind = req.RequestKind.Group, req.RequestKind.Version, req.RequestKind.Kind
-	}
-	if req.RequestResource != nil {
-		group, version, resource = req.RequestResource.Group, req.RequestResource.Version, req.RequestResource.Resource
-	}
-
-	return checkString(r.kind, kind) &&
-		checkString(r.resource, resource) &&
+	return checkString(r.kind, req.Kind.Kind) &&
+		checkString(r.resource, req.Resource.Resource) &&
 		checkString(r.subResource, req.SubResource) &&
-		checkString(r.version, version) &&
-		checkString(r.group, group) &&
+		checkString(r.version, req.Kind.Version) &&
+		checkString(r.group, req.Kind.Group) &&
 		checkString(r.name, req.Name) &&
 		checkString(r.namespace, req.Namespace) &&
 		checkString(string(r.operation), string(req.Operation)) &&

--- a/pkg/webhook/router.go
+++ b/pkg/webhook/router.go
@@ -45,7 +45,7 @@ func writeResponse(rw http.ResponseWriter, review *v1.AdmissionReview) {
 	json.NewEncoder(rw).Encode(review)
 }
 
-// ServeHTTP inspects the http.Request and calls the Admit function on all matching handlers.
+// ServeHTTP inspects the http.Request and calls the Admit function on the first matching RouteMatch.
 func (r *Router) ServeHTTP(rw http.ResponseWriter, req *http.Request) {
 	review := &v1.AdmissionReview{}
 	err := json.NewDecoder(req.Body).Decode(review)


### PR DESCRIPTION
The previous implementation of the match function used the RequestKind and RequestResource, which hold the GVK and GVR of the original object before any conversions were made. This negates the use of Kubernetes match policy.

If the creator of the handler function does not want to accept converted objects, they should update their webhook configuration and set the mathPolicy to `Exact`

Docs: https://kubernetes.io/docs/reference/access-authn-authz/extensible-admission-controllers/#matching-requests-matchpolicy