### PR TITLE
Fix CreateUnknownIfNotExists to work on status objects

### DIFF
--- a/pkg/condition/condition.go
+++ b/pkg/condition/condition.go
@@ -89,6 +89,9 @@ func (c Cond) GetLastUpdated(obj interface{}) string {
 
 func (c Cond) CreateUnknownIfNotExists(obj interface{}) {
 	condSlice := getValue(obj, "Status", "Conditions")
+	if !condSlice.IsValid() {
+		condSlice = getValue(obj, "Conditions")
+	}
 	cond := findCond(obj, condSlice, string(c))
 	if cond == nil {
 		c.Unknown(obj)


### PR DESCRIPTION
#252

Add checks from [`87c25c8` (#77)](https://github.com/rancher/wrangler/pull/77/commits/87c25c813af5e245bc035112dd01fed1d77951a8) to `CreateUnknownIfExists`