### PR TITLE
Moving linting to GitHub Actions

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -11,8 +11,6 @@ steps:
   - name: test
     image: registry.suse.com/bci/golang:1.19
     commands:
-      - zypper -n install tar gzip
-      - "curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s v1.51.1;"
       - ./scripts/ci
     volumes:
       - name: docker

--- a/.github/dependabot.yaml
+++ b/.github/dependabot.yaml
@@ -7,3 +7,10 @@ updates:
       interval: "weekly"
     labels:
       - "dependencies"
+  -
+    package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "monthly"
+    labels:
+      - "dependencies"

--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -1,0 +1,38 @@
+name: golangci-lint
+
+env:
+  SETUP_GO_VERSION: '^1.19'
+
+on:
+  push:
+  pull_request:
+    tags:
+      - v*
+    branches:
+      - 'release/*'
+      - 'master'
+
+jobs:
+  golangci:
+    name: golangci-lint
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+        with:
+          submodules: recursive
+
+      - name: Setup Go
+        uses: actions/setup-go@v3
+        with:
+          go-version: ${{ env.SETUP_GO_VERSION }}
+
+      - name: Generate Golang
+        run: |
+          export PATH=$PATH:/home/runner/go/bin/
+
+      - name: golangci-lint
+        uses: golangci/golangci-lint-action@v3.4.0
+        with:
+          # Required: the version of golangci-lint is required and must be specified without patch version: we always use the latest patch version.
+          version: v1.51


### PR DESCRIPTION
The GitHub Action can display, right in the code (i.e. PR), where the lint issue is at. This can provide more direct feedback to PR authors.

Note, dependabot will create PRs for the GitHub Action but not for the version of the linter that's specified in the configuration.