### PR TITLE
Fix schema generation for IntOrString

### DIFF
--- a/pkg/schemas/openapi/generate.go
+++ b/pkg/schemas/openapi/generate.go
@@ -140,6 +140,8 @@ func typeToProps(typeName string, schemas *types.Schemas, inflight map[string]bo
 	case "string":
 		jsp.Type = t
 		jsp.Nullable = true
+	case "intOrString":
+		jsp.XIntOrString = true
 	default:
 		jsp.Type = t
 	}
@@ -201,9 +203,8 @@ func typeAndSchema(typeName string, schemas *types.Schemas) (string, string, *ty
 	}
 
 	switch typeName {
-	// TODO: in v1 set the x- header for this
 	case "intOrString":
-		return "string", "", nil, nil
+		return "intOrString", "", nil, nil
 	case "int":
 		return "integer", "", nil, nil
 	case "float":


### PR DESCRIPTION
The IntOrString type is currently generated as a string, which is incorrect. It should use the XIntOrString bool to specify that either integer or string values are allowed.

Ref: https://github.com/kubernetes/apiextensions-apiserver/blob/v0.24.0/pkg/apis/apiextensions/v1/types_jsonschema.go#L107-L120

There was even a TODO in the code for fixing this once apiextensions hit v1.

## Issue Description

Fixes an issue where IntOrString fields with integer values are rejected with messages like:

`The HelmChart "cert-manager" is invalid: spec.set.webhook.timeoutSeconds: Invalid value: "integer": spec.set.webhook.timeoutSeconds in body must be of type string: "integer"`

`spec.set` is an IntOrString field, but the wrangler-generated openapi v3 schema rejects it as described above.

## Linked Issue
* https://github.com/k3s-io/k3s/issues/7310