### PR TITLE
readme: typo, if obj is nil, it should return directly

### DIFF
--- a/README.md
+++ b/README.md
@@ -237,7 +237,7 @@ users := mgmt.Management().V3().User("")
 configmaps := core.Management().Core().Configmaps("examplenamespace")
 
 syncHandler := func(id string, obj *v3.User) (*v3.User, error) {
-	if obj != nil {
+	if obj == nil {
 		return obj, nil
 	}
 


### PR DESCRIPTION
I'm not sure about this.
But I thought this is a typo.
If `obj` is `nil`, controller will not get/set any data to `obj`.