### PR TITLE
Allow GeneratingHandlers to skip Apply if resource version didn't change

### DIFF
--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -18,7 +18,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           submodules: recursive
 
@@ -32,7 +32,7 @@ jobs:
           export PATH=$PATH:/home/runner/go/bin/
 
       - name: golangci-lint
-        uses: golangci/golangci-lint-action@v3.4.0
+        uses: golangci/golangci-lint-action@v3.7.0
         with:
           # Required: the version of golangci-lint is required and must be specified without patch version: we always use the latest patch version.
-          version: v1.51
+          version: v1.55

--- a/pkg/apply/fake/apply.go
+++ b/pkg/apply/fake/apply.go
@@ -14,18 +14,19 @@ var _ apply.Apply = (*FakeApply)(nil)
 
 type FakeApply struct {
 	Objects []*objectset.ObjectSet
+	Count   int
 }
 
 func (f *FakeApply) Apply(set *objectset.ObjectSet) error {
 	f.Objects = append(f.Objects, set)
+	f.Count++
 	return nil
 }
 
 func (f *FakeApply) ApplyObjects(objs ...runtime.Object) error {
 	os := objectset.NewObjectSet()
 	os.Add(objs...)
-	f.Objects = append(f.Objects, os)
-	return nil
+	return f.Apply(os)
 }
 
 func (f *FakeApply) WithCacheTypes(igs ...apply.InformerGetter) apply.Apply {

--- a/pkg/controller-gen/generators/type_go.go
+++ b/pkg/controller-gen/generators/type_go.go
@@ -205,8 +205,11 @@ func (a *{{.lowerName}}GeneratingHandler) Handle(obj *{{.version}}.{{.type}}, st
 	}
 
 	objs, newStatus, err := a.{{.type}}GeneratingHandler(obj, status)
-	if err != nil || !a.isNewResourceVersion(obj) {
+	if err != nil {
 		return newStatus, err
+	}
+	if !a.isNewResourceVersion(obj) {
+	    return newStatus, nil
 	}
 
 	err = generic.ConfigureApplyForObject(a.apply, obj, &a.opts).

--- a/pkg/controller-gen/generators/type_go.go
+++ b/pkg/controller-gen/generators/type_go.go
@@ -219,7 +219,7 @@ func (a *{{.lowerName}}GeneratingHandler) Handle(obj *{{.version}}.{{.type}}, st
 	if err != nil {
 		return newStatus, err
 	}
-	a.seenResourceVersion(obj)
+	a.storeResourceVersion(obj)
 	return newStatus, nil
 }
 
@@ -234,7 +234,7 @@ func (a *{{.lowerName}}GeneratingHandler) isNewResourceVersion(obj *{{.version}}
 	return !ok || previous != obj.ResourceVersion
 }
 
-func (a *{{.lowerName}}GeneratingHandler) seenResourceVersion(obj *{{.version}}.{{.type}}) {
+func (a *{{.lowerName}}GeneratingHandler) storeResourceVersion(obj *{{.version}}.{{.type}}) {
 	if !a.opts.UniqueApplyForResourceVersion {
 		return
 	}

--- a/pkg/controller-gen/generators/type_go.go
+++ b/pkg/controller-gen/generators/type_go.go
@@ -213,10 +213,11 @@ func (a *{{.lowerName}}GeneratingHandler) Handle(obj *{{.version}}.{{.type}}, st
 		WithOwner(obj).
 		WithSetID(a.name).
 		ApplyObjects(objs...)
-	if err == nil {
-		a.seenResourceVersion(obj)
+	if err != nil {
+		return newStatus, err
 	}
-	return newStatus, err
+	a.seenResourceVersion(obj)
+	return newStatus, nil
 }
 
 func (a *{{.lowerName}}GeneratingHandler) isNewResourceVersion(obj *{{.version}}.{{.type}}) bool {

--- a/pkg/controller-gen/generators/util.go
+++ b/pkg/controller-gen/generators/util.go
@@ -11,6 +11,7 @@ import (
 var (
 	Imports = []string{
 		"context",
+		"sync",
 		"time",
 		"k8s.io/client-go/rest",
 		"github.com/rancher/wrangler/v2/pkg/apply",

--- a/pkg/generated/controllers/apiextensions.k8s.io/v1/customresourcedefinition.go
+++ b/pkg/generated/controllers/apiextensions.k8s.io/v1/customresourcedefinition.go
@@ -156,18 +156,22 @@ func (a *customResourceDefinitionGeneratingHandler) Handle(obj *v1.CustomResourc
 	}
 
 	objs, newStatus, err := a.CustomResourceDefinitionGeneratingHandler(obj, status)
-	if err != nil || !a.isNewResourceVersion(obj) {
+	if err != nil {
 		return newStatus, err
+	}
+	if !a.isNewResourceVersion(obj) {
+		return newStatus, nil
 	}
 
 	err = generic.ConfigureApplyForObject(a.apply, obj, &a.opts).
 		WithOwner(obj).
 		WithSetID(a.name).
 		ApplyObjects(objs...)
-	if err == nil {
-		a.seenResourceVersion(obj)
+	if err != nil {
+		return newStatus, err
 	}
-	return newStatus, err
+	a.storeResourceVersion(obj)
+	return newStatus, nil
 }
 
 func (a *customResourceDefinitionGeneratingHandler) isNewResourceVersion(obj *v1.CustomResourceDefinition) bool {
@@ -181,7 +185,7 @@ func (a *customResourceDefinitionGeneratingHandler) isNewResourceVersion(obj *v1
 	return !ok || previous != obj.ResourceVersion
 }
 
-func (a *customResourceDefinitionGeneratingHandler) seenResourceVersion(obj *v1.CustomResourceDefinition) {
+func (a *customResourceDefinitionGeneratingHandler) storeResourceVersion(obj *v1.CustomResourceDefinition) {
 	if !a.opts.UniqueApplyForResourceVersion {
 		return
 	}

--- a/pkg/generated/controllers/apiextensions.k8s.io/v1/customresourcedefinition.go
+++ b/pkg/generated/controllers/apiextensions.k8s.io/v1/customresourcedefinition.go
@@ -20,6 +20,7 @@ package v1
 
 import (
 	"context"
+	"sync"
 	"time"
 
 	"github.com/rancher/wrangler/v2/pkg/apply"
@@ -127,6 +128,7 @@ type customResourceDefinitionGeneratingHandler struct {
 	opts  generic.GeneratingHandlerOptions
 	gvk   schema.GroupVersionKind
 	name  string
+	seen  sync.Map
 }
 
 func (a *customResourceDefinitionGeneratingHandler) Remove(key string, obj *v1.CustomResourceDefinition) (*v1.CustomResourceDefinition, error) {
@@ -137,6 +139,10 @@ func (a *customResourceDefinitionGeneratingHandler) Remove(key string, obj *v1.C
 	obj = &v1.CustomResourceDefinition{}
 	obj.Namespace, obj.Name = kv.RSplit(key, "/")
 	obj.SetGroupVersionKind(a.gvk)
+
+	if a.opts.UniqueApplyForResourceVersion {
+		a.seen.Delete(key)
+	}
 
 	return nil, generic.ConfigureApplyForObject(a.apply, obj, &a.opts).
 		WithOwner(obj).
@@ -150,12 +156,36 @@ func (a *customResourceDefinitionGeneratingHandler) Handle(obj *v1.CustomResourc
 	}
 
 	objs, newStatus, err := a.CustomResourceDefinitionGeneratingHandler(obj, status)
-	if err != nil {
+	if err != nil || !a.isNewResourceVersion(obj) {
 		return newStatus, err
 	}
 
-	return newStatus, generic.ConfigureApplyForObject(a.apply, obj, &a.opts).
+	err = generic.ConfigureApplyForObject(a.apply, obj, &a.opts).
 		WithOwner(obj).
 		WithSetID(a.name).
 		ApplyObjects(objs...)
+	if err == nil {
+		a.seenResourceVersion(obj)
+	}
+	return newStatus, err
+}
+
+func (a *customResourceDefinitionGeneratingHandler) isNewResourceVersion(obj *v1.CustomResourceDefinition) bool {
+	if !a.opts.UniqueApplyForResourceVersion {
+		return true
+	}
+
+	// Apply once per resource version
+	key := obj.Namespace + "/" + obj.Name
+	previous, ok := a.seen.Load(key)
+	return !ok || previous != obj.ResourceVersion
+}
+
+func (a *customResourceDefinitionGeneratingHandler) seenResourceVersion(obj *v1.CustomResourceDefinition) {
+	if !a.opts.UniqueApplyForResourceVersion {
+		return
+	}
+
+	key := obj.Namespace + "/" + obj.Name
+	a.seen.Store(key, obj.ResourceVersion)
 }

--- a/pkg/generated/controllers/apiregistration.k8s.io/v1/apiservice.go
+++ b/pkg/generated/controllers/apiregistration.k8s.io/v1/apiservice.go
@@ -20,6 +20,7 @@ package v1
 
 import (
 	"context"
+	"sync"
 	"time"
 
 	"github.com/rancher/wrangler/v2/pkg/apply"
@@ -127,6 +128,7 @@ type aPIServiceGeneratingHandler struct {
 	opts  generic.GeneratingHandlerOptions
 	gvk   schema.GroupVersionKind
 	name  string
+	seen  sync.Map
 }
 
 func (a *aPIServiceGeneratingHandler) Remove(key string, obj *v1.APIService) (*v1.APIService, error) {
@@ -137,6 +139,10 @@ func (a *aPIServiceGeneratingHandler) Remove(key string, obj *v1.APIService) (*v
 	obj = &v1.APIService{}
 	obj.Namespace, obj.Name = kv.RSplit(key, "/")
 	obj.SetGroupVersionKind(a.gvk)
+
+	if a.opts.UniqueApplyForResourceVersion {
+		a.seen.Delete(key)
+	}
 
 	return nil, generic.ConfigureApplyForObject(a.apply, obj, &a.opts).
 		WithOwner(obj).
@@ -150,12 +156,36 @@ func (a *aPIServiceGeneratingHandler) Handle(obj *v1.APIService, status v1.APISe
 	}
 
 	objs, newStatus, err := a.APIServiceGeneratingHandler(obj, status)
-	if err != nil {
+	if err != nil || !a.isNewResourceVersion(obj) {
 		return newStatus, err
 	}
 
-	return newStatus, generic.ConfigureApplyForObject(a.apply, obj, &a.opts).
+	err = generic.ConfigureApplyForObject(a.apply, obj, &a.opts).
 		WithOwner(obj).
 		WithSetID(a.name).
 		ApplyObjects(objs...)
+	if err == nil {
+		a.seenResourceVersion(obj)
+	}
+	return newStatus, err
+}
+
+func (a *aPIServiceGeneratingHandler) isNewResourceVersion(obj *v1.APIService) bool {
+	if !a.opts.UniqueApplyForResourceVersion {
+		return true
+	}
+
+	// Apply once per resource version
+	key := obj.Namespace + "/" + obj.Name
+	previous, ok := a.seen.Load(key)
+	return !ok || previous != obj.ResourceVersion
+}
+
+func (a *aPIServiceGeneratingHandler) seenResourceVersion(obj *v1.APIService) {
+	if !a.opts.UniqueApplyForResourceVersion {
+		return
+	}
+
+	key := obj.Namespace + "/" + obj.Name
+	a.seen.Store(key, obj.ResourceVersion)
 }

--- a/pkg/generated/controllers/apps/v1/daemonset.go
+++ b/pkg/generated/controllers/apps/v1/daemonset.go
@@ -20,6 +20,7 @@ package v1
 
 import (
 	"context"
+	"sync"
 	"time"
 
 	"github.com/rancher/wrangler/v2/pkg/apply"
@@ -127,6 +128,7 @@ type daemonSetGeneratingHandler struct {
 	opts  generic.GeneratingHandlerOptions
 	gvk   schema.GroupVersionKind
 	name  string
+	seen  sync.Map
 }
 
 func (a *daemonSetGeneratingHandler) Remove(key string, obj *v1.DaemonSet) (*v1.DaemonSet, error) {
@@ -137,6 +139,10 @@ func (a *daemonSetGeneratingHandler) Remove(key string, obj *v1.DaemonSet) (*v1.
 	obj = &v1.DaemonSet{}
 	obj.Namespace, obj.Name = kv.RSplit(key, "/")
 	obj.SetGroupVersionKind(a.gvk)
+
+	if a.opts.UniqueApplyForResourceVersion {
+		a.seen.Delete(key)
+	}
 
 	return nil, generic.ConfigureApplyForObject(a.apply, obj, &a.opts).
 		WithOwner(obj).
@@ -150,12 +156,36 @@ func (a *daemonSetGeneratingHandler) Handle(obj *v1.DaemonSet, status v1.DaemonS
 	}
 
 	objs, newStatus, err := a.DaemonSetGeneratingHandler(obj, status)
-	if err != nil {
+	if err != nil || !a.isNewResourceVersion(obj) {
 		return newStatus, err
 	}
 
-	return newStatus, generic.ConfigureApplyForObject(a.apply, obj, &a.opts).
+	err = generic.ConfigureApplyForObject(a.apply, obj, &a.opts).
 		WithOwner(obj).
 		WithSetID(a.name).
 		ApplyObjects(objs...)
+	if err == nil {
+		a.seenResourceVersion(obj)
+	}
+	return newStatus, err
+}
+
+func (a *daemonSetGeneratingHandler) isNewResourceVersion(obj *v1.DaemonSet) bool {
+	if !a.opts.UniqueApplyForResourceVersion {
+		return true
+	}
+
+	// Apply once per resource version
+	key := obj.Namespace + "/" + obj.Name
+	previous, ok := a.seen.Load(key)
+	return !ok || previous != obj.ResourceVersion
+}
+
+func (a *daemonSetGeneratingHandler) seenResourceVersion(obj *v1.DaemonSet) {
+	if !a.opts.UniqueApplyForResourceVersion {
+		return
+	}
+
+	key := obj.Namespace + "/" + obj.Name
+	a.seen.Store(key, obj.ResourceVersion)
 }

--- a/pkg/generated/controllers/apps/v1/deployment.go
+++ b/pkg/generated/controllers/apps/v1/deployment.go
@@ -20,6 +20,7 @@ package v1
 
 import (
 	"context"
+	"sync"
 	"time"
 
 	"github.com/rancher/wrangler/v2/pkg/apply"
@@ -127,6 +128,7 @@ type deploymentGeneratingHandler struct {
 	opts  generic.GeneratingHandlerOptions
 	gvk   schema.GroupVersionKind
 	name  string
+	seen  sync.Map
 }
 
 func (a *deploymentGeneratingHandler) Remove(key string, obj *v1.Deployment) (*v1.Deployment, error) {
@@ -137,6 +139,10 @@ func (a *deploymentGeneratingHandler) Remove(key string, obj *v1.Deployment) (*v
 	obj = &v1.Deployment{}
 	obj.Namespace, obj.Name = kv.RSplit(key, "/")
 	obj.SetGroupVersionKind(a.gvk)
+
+	if a.opts.UniqueApplyForResourceVersion {
+		a.seen.Delete(key)
+	}
 
 	return nil, generic.ConfigureApplyForObject(a.apply, obj, &a.opts).
 		WithOwner(obj).
@@ -150,12 +156,36 @@ func (a *deploymentGeneratingHandler) Handle(obj *v1.Deployment, status v1.Deplo
 	}
 
 	objs, newStatus, err := a.DeploymentGeneratingHandler(obj, status)
-	if err != nil {
+	if err != nil || !a.isNewResourceVersion(obj) {
 		return newStatus, err
 	}
 
-	return newStatus, generic.ConfigureApplyForObject(a.apply, obj, &a.opts).
+	err = generic.ConfigureApplyForObject(a.apply, obj, &a.opts).
 		WithOwner(obj).
 		WithSetID(a.name).
 		ApplyObjects(objs...)
+	if err == nil {
+		a.seenResourceVersion(obj)
+	}
+	return newStatus, err
+}
+
+func (a *deploymentGeneratingHandler) isNewResourceVersion(obj *v1.Deployment) bool {
+	if !a.opts.UniqueApplyForResourceVersion {
+		return true
+	}
+
+	// Apply once per resource version
+	key := obj.Namespace + "/" + obj.Name
+	previous, ok := a.seen.Load(key)
+	return !ok || previous != obj.ResourceVersion
+}
+
+func (a *deploymentGeneratingHandler) seenResourceVersion(obj *v1.Deployment) {
+	if !a.opts.UniqueApplyForResourceVersion {
+		return
+	}
+
+	key := obj.Namespace + "/" + obj.Name
+	a.seen.Store(key, obj.ResourceVersion)
 }

--- a/pkg/generated/controllers/apps/v1/deployment.go
+++ b/pkg/generated/controllers/apps/v1/deployment.go
@@ -156,18 +156,22 @@ func (a *deploymentGeneratingHandler) Handle(obj *v1.Deployment, status v1.Deplo
 	}
 
 	objs, newStatus, err := a.DeploymentGeneratingHandler(obj, status)
-	if err != nil || !a.isNewResourceVersion(obj) {
+	if err != nil {
 		return newStatus, err
+	}
+	if !a.isNewResourceVersion(obj) {
+		return newStatus, nil
 	}
 
 	err = generic.ConfigureApplyForObject(a.apply, obj, &a.opts).
 		WithOwner(obj).
 		WithSetID(a.name).
 		ApplyObjects(objs...)
-	if err == nil {
-		a.seenResourceVersion(obj)
+	if err != nil {
+		return newStatus, err
 	}
-	return newStatus, err
+	a.storeResourceVersion(obj)
+	return newStatus, nil
 }
 
 func (a *deploymentGeneratingHandler) isNewResourceVersion(obj *v1.Deployment) bool {
@@ -181,7 +185,7 @@ func (a *deploymentGeneratingHandler) isNewResourceVersion(obj *v1.Deployment) b
 	return !ok || previous != obj.ResourceVersion
 }
 
-func (a *deploymentGeneratingHandler) seenResourceVersion(obj *v1.Deployment) {
+func (a *deploymentGeneratingHandler) storeResourceVersion(obj *v1.Deployment) {
 	if !a.opts.UniqueApplyForResourceVersion {
 		return
 	}

--- a/pkg/generated/controllers/apps/v1/statefulset.go
+++ b/pkg/generated/controllers/apps/v1/statefulset.go
@@ -20,6 +20,7 @@ package v1
 
 import (
 	"context"
+	"sync"
 	"time"
 
 	"github.com/rancher/wrangler/v2/pkg/apply"
@@ -127,6 +128,7 @@ type statefulSetGeneratingHandler struct {
 	opts  generic.GeneratingHandlerOptions
 	gvk   schema.GroupVersionKind
 	name  string
+	seen  sync.Map
 }
 
 func (a *statefulSetGeneratingHandler) Remove(key string, obj *v1.StatefulSet) (*v1.StatefulSet, error) {
@@ -137,6 +139,10 @@ func (a *statefulSetGeneratingHandler) Remove(key string, obj *v1.StatefulSet) (
 	obj = &v1.StatefulSet{}
 	obj.Namespace, obj.Name = kv.RSplit(key, "/")
 	obj.SetGroupVersionKind(a.gvk)
+
+	if a.opts.UniqueApplyForResourceVersion {
+		a.seen.Delete(key)
+	}
 
 	return nil, generic.ConfigureApplyForObject(a.apply, obj, &a.opts).
 		WithOwner(obj).
@@ -150,12 +156,36 @@ func (a *statefulSetGeneratingHandler) Handle(obj *v1.StatefulSet, status v1.Sta
 	}
 
 	objs, newStatus, err := a.StatefulSetGeneratingHandler(obj, status)
-	if err != nil {
+	if err != nil || !a.isNewResourceVersion(obj) {
 		return newStatus, err
 	}
 
-	return newStatus, generic.ConfigureApplyForObject(a.apply, obj, &a.opts).
+	err = generic.ConfigureApplyForObject(a.apply, obj, &a.opts).
 		WithOwner(obj).
 		WithSetID(a.name).
 		ApplyObjects(objs...)
+	if err == nil {
+		a.seenResourceVersion(obj)
+	}
+	return newStatus, err
+}
+
+func (a *statefulSetGeneratingHandler) isNewResourceVersion(obj *v1.StatefulSet) bool {
+	if !a.opts.UniqueApplyForResourceVersion {
+		return true
+	}
+
+	// Apply once per resource version
+	key := obj.Namespace + "/" + obj.Name
+	previous, ok := a.seen.Load(key)
+	return !ok || previous != obj.ResourceVersion
+}
+
+func (a *statefulSetGeneratingHandler) seenResourceVersion(obj *v1.StatefulSet) {
+	if !a.opts.UniqueApplyForResourceVersion {
+		return
+	}
+
+	key := obj.Namespace + "/" + obj.Name
+	a.seen.Store(key, obj.ResourceVersion)
 }

--- a/pkg/generated/controllers/core/v1/namespace.go
+++ b/pkg/generated/controllers/core/v1/namespace.go
@@ -20,6 +20,7 @@ package v1
 
 import (
 	"context"
+	"sync"
 	"time"
 
 	"github.com/rancher/wrangler/v2/pkg/apply"
@@ -127,6 +128,7 @@ type namespaceGeneratingHandler struct {
 	opts  generic.GeneratingHandlerOptions
 	gvk   schema.GroupVersionKind
 	name  string
+	seen  sync.Map
 }
 
 func (a *namespaceGeneratingHandler) Remove(key string, obj *v1.Namespace) (*v1.Namespace, error) {
@@ -137,6 +139,10 @@ func (a *namespaceGeneratingHandler) Remove(key string, obj *v1.Namespace) (*v1.
 	obj = &v1.Namespace{}
 	obj.Namespace, obj.Name = kv.RSplit(key, "/")
 	obj.SetGroupVersionKind(a.gvk)
+
+	if a.opts.UniqueApplyForResourceVersion {
+		a.seen.Delete(key)
+	}
 
 	return nil, generic.ConfigureApplyForObject(a.apply, obj, &a.opts).
 		WithOwner(obj).
@@ -150,12 +156,36 @@ func (a *namespaceGeneratingHandler) Handle(obj *v1.Namespace, status v1.Namespa
 	}
 
 	objs, newStatus, err := a.NamespaceGeneratingHandler(obj, status)
-	if err != nil {
+	if err != nil || !a.isNewResourceVersion(obj) {
 		return newStatus, err
 	}
 
-	return newStatus, generic.ConfigureApplyForObject(a.apply, obj, &a.opts).
+	err = generic.ConfigureApplyForObject(a.apply, obj, &a.opts).
 		WithOwner(obj).
 		WithSetID(a.name).
 		ApplyObjects(objs...)
+	if err == nil {
+		a.seenResourceVersion(obj)
+	}
+	return newStatus, err
+}
+
+func (a *namespaceGeneratingHandler) isNewResourceVersion(obj *v1.Namespace) bool {
+	if !a.opts.UniqueApplyForResourceVersion {
+		return true
+	}
+
+	// Apply once per resource version
+	key := obj.Namespace + "/" + obj.Name
+	previous, ok := a.seen.Load(key)
+	return !ok || previous != obj.ResourceVersion
+}
+
+func (a *namespaceGeneratingHandler) seenResourceVersion(obj *v1.Namespace) {
+	if !a.opts.UniqueApplyForResourceVersion {
+		return
+	}
+
+	key := obj.Namespace + "/" + obj.Name
+	a.seen.Store(key, obj.ResourceVersion)
 }

--- a/pkg/generated/controllers/core/v1/node.go
+++ b/pkg/generated/controllers/core/v1/node.go
@@ -49,10 +49,14 @@ type NodeCache interface {
 	generic.NonNamespacedCacheInterface[*v1.Node]
 }
 
+// NodeStatusHandler is executed for every added or modified Node. Should return the new status to be updated
 type NodeStatusHandler func(obj *v1.Node, status v1.NodeStatus) (v1.NodeStatus, error)
 
+// NodeGeneratingHandler is the top-level handler that is executed for every Node event. It extends NodeStatusHandler by a returning a slice of child objects to be passed to apply.Apply
 type NodeGeneratingHandler func(obj *v1.Node, status v1.NodeStatus) ([]runtime.Object, v1.NodeStatus, error)
 
+// RegisterNodeStatusHandler configures a NodeController to execute a NodeStatusHandler for every events observed.
+// If a non-empty condition is provided, it will be updated in the status conditions for every handler execution
 func RegisterNodeStatusHandler(ctx context.Context, controller NodeController, condition condition.Cond, name string, handler NodeStatusHandler) {
 	statusHandler := &nodeStatusHandler{
 		client:    controller,
@@ -62,6 +66,8 @@ func RegisterNodeStatusHandler(ctx context.Context, controller NodeController, c
 	controller.AddGenericHandler(ctx, name, generic.FromObjectHandlerToHandler(statusHandler.sync))
 }
 
+// RegisterNodeGeneratingHandler configures a NodeController to execute a NodeGeneratingHandler for every events observed, passing the returned objects to the provided apply.Apply.
+// If a non-empty condition is provided, it will be updated in the status conditions for every handler execution
 func RegisterNodeGeneratingHandler(ctx context.Context, controller NodeController, apply apply.Apply,
 	condition condition.Cond, name string, handler NodeGeneratingHandler, opts *generic.GeneratingHandlerOptions) {
 	statusHandler := &nodeGeneratingHandler{
@@ -83,6 +89,7 @@ type nodeStatusHandler struct {
 	handler   NodeStatusHandler
 }
 
+// sync is executed on every resource addition or modification. Executes the configured handlers and sends the updated status to the Kubernetes API
 func (a *nodeStatusHandler) sync(key string, obj *v1.Node) (*v1.Node, error) {
 	if obj == nil {
 		return obj, nil
@@ -131,6 +138,7 @@ type nodeGeneratingHandler struct {
 	seen  sync.Map
 }
 
+// Remove handles the observed deletion of a resource, cascade deleting every associated resource previously applied
 func (a *nodeGeneratingHandler) Remove(key string, obj *v1.Node) (*v1.Node, error) {
 	if obj != nil {
 		return obj, nil
@@ -150,6 +158,7 @@ func (a *nodeGeneratingHandler) Remove(key string, obj *v1.Node) (*v1.Node, erro
 		ApplyObjects()
 }
 
+// Handle executes the configured NodeGeneratingHandler and pass the resulting objects to apply.Apply, finally returning the new status of the resource
 func (a *nodeGeneratingHandler) Handle(obj *v1.Node, status v1.NodeStatus) (v1.NodeStatus, error) {
 	if !obj.DeletionTimestamp.IsZero() {
 		return status, nil
@@ -174,6 +183,8 @@ func (a *nodeGeneratingHandler) Handle(obj *v1.Node, status v1.NodeStatus) (v1.N
 	return newStatus, nil
 }
 
+// isNewResourceVersion detects if a specific resource version was already successfully processed.
+// Only used if UniqueApplyForResourceVersion is set in generic.GeneratingHandlerOptions
 func (a *nodeGeneratingHandler) isNewResourceVersion(obj *v1.Node) bool {
 	if !a.opts.UniqueApplyForResourceVersion {
 		return true
@@ -185,6 +196,8 @@ func (a *nodeGeneratingHandler) isNewResourceVersion(obj *v1.Node) bool {
 	return !ok || previous != obj.ResourceVersion
 }
 
+// storeResourceVersion keeps track of the latest resource version of an object for which Apply was executed
+// Only used if UniqueApplyForResourceVersion is set in generic.GeneratingHandlerOptions
 func (a *nodeGeneratingHandler) storeResourceVersion(obj *v1.Node) {
 	if !a.opts.UniqueApplyForResourceVersion {
 		return

--- a/pkg/generated/controllers/core/v1/persistentvolume.go
+++ b/pkg/generated/controllers/core/v1/persistentvolume.go
@@ -156,18 +156,22 @@ func (a *persistentVolumeGeneratingHandler) Handle(obj *v1.PersistentVolume, sta
 	}
 
 	objs, newStatus, err := a.PersistentVolumeGeneratingHandler(obj, status)
-	if err != nil || !a.isNewResourceVersion(obj) {
+	if err != nil {
 		return newStatus, err
+	}
+	if !a.isNewResourceVersion(obj) {
+		return newStatus, nil
 	}
 
 	err = generic.ConfigureApplyForObject(a.apply, obj, &a.opts).
 		WithOwner(obj).
 		WithSetID(a.name).
 		ApplyObjects(objs...)
-	if err == nil {
-		a.seenResourceVersion(obj)
+	if err != nil {
+		return newStatus, err
 	}
-	return newStatus, err
+	a.storeResourceVersion(obj)
+	return newStatus, nil
 }
 
 func (a *persistentVolumeGeneratingHandler) isNewResourceVersion(obj *v1.PersistentVolume) bool {
@@ -181,7 +185,7 @@ func (a *persistentVolumeGeneratingHandler) isNewResourceVersion(obj *v1.Persist
 	return !ok || previous != obj.ResourceVersion
 }
 
-func (a *persistentVolumeGeneratingHandler) seenResourceVersion(obj *v1.PersistentVolume) {
+func (a *persistentVolumeGeneratingHandler) storeResourceVersion(obj *v1.PersistentVolume) {
 	if !a.opts.UniqueApplyForResourceVersion {
 		return
 	}

--- a/pkg/generated/controllers/core/v1/persistentvolume.go
+++ b/pkg/generated/controllers/core/v1/persistentvolume.go
@@ -20,6 +20,7 @@ package v1
 
 import (
 	"context"
+	"sync"
 	"time"
 
 	"github.com/rancher/wrangler/v2/pkg/apply"
@@ -127,6 +128,7 @@ type persistentVolumeGeneratingHandler struct {
 	opts  generic.GeneratingHandlerOptions
 	gvk   schema.GroupVersionKind
 	name  string
+	seen  sync.Map
 }
 
 func (a *persistentVolumeGeneratingHandler) Remove(key string, obj *v1.PersistentVolume) (*v1.PersistentVolume, error) {
@@ -137,6 +139,10 @@ func (a *persistentVolumeGeneratingHandler) Remove(key string, obj *v1.Persisten
 	obj = &v1.PersistentVolume{}
 	obj.Namespace, obj.Name = kv.RSplit(key, "/")
 	obj.SetGroupVersionKind(a.gvk)
+
+	if a.opts.UniqueApplyForResourceVersion {
+		a.seen.Delete(key)
+	}
 
 	return nil, generic.ConfigureApplyForObject(a.apply, obj, &a.opts).
 		WithOwner(obj).
@@ -150,12 +156,36 @@ func (a *persistentVolumeGeneratingHandler) Handle(obj *v1.PersistentVolume, sta
 	}
 
 	objs, newStatus, err := a.PersistentVolumeGeneratingHandler(obj, status)
-	if err != nil {
+	if err != nil || !a.isNewResourceVersion(obj) {
 		return newStatus, err
 	}
 
-	return newStatus, generic.ConfigureApplyForObject(a.apply, obj, &a.opts).
+	err = generic.ConfigureApplyForObject(a.apply, obj, &a.opts).
 		WithOwner(obj).
 		WithSetID(a.name).
 		ApplyObjects(objs...)
+	if err == nil {
+		a.seenResourceVersion(obj)
+	}
+	return newStatus, err
+}
+
+func (a *persistentVolumeGeneratingHandler) isNewResourceVersion(obj *v1.PersistentVolume) bool {
+	if !a.opts.UniqueApplyForResourceVersion {
+		return true
+	}
+
+	// Apply once per resource version
+	key := obj.Namespace + "/" + obj.Name
+	previous, ok := a.seen.Load(key)
+	return !ok || previous != obj.ResourceVersion
+}
+
+func (a *persistentVolumeGeneratingHandler) seenResourceVersion(obj *v1.PersistentVolume) {
+	if !a.opts.UniqueApplyForResourceVersion {
+		return
+	}
+
+	key := obj.Namespace + "/" + obj.Name
+	a.seen.Store(key, obj.ResourceVersion)
 }

--- a/pkg/generated/controllers/core/v1/persistentvolumeclaim.go
+++ b/pkg/generated/controllers/core/v1/persistentvolumeclaim.go
@@ -20,6 +20,7 @@ package v1
 
 import (
 	"context"
+	"sync"
 	"time"
 
 	"github.com/rancher/wrangler/v2/pkg/apply"
@@ -127,6 +128,7 @@ type persistentVolumeClaimGeneratingHandler struct {
 	opts  generic.GeneratingHandlerOptions
 	gvk   schema.GroupVersionKind
 	name  string
+	seen  sync.Map
 }
 
 func (a *persistentVolumeClaimGeneratingHandler) Remove(key string, obj *v1.PersistentVolumeClaim) (*v1.PersistentVolumeClaim, error) {
@@ -137,6 +139,10 @@ func (a *persistentVolumeClaimGeneratingHandler) Remove(key string, obj *v1.Pers
 	obj = &v1.PersistentVolumeClaim{}
 	obj.Namespace, obj.Name = kv.RSplit(key, "/")
 	obj.SetGroupVersionKind(a.gvk)
+
+	if a.opts.UniqueApplyForResourceVersion {
+		a.seen.Delete(key)
+	}
 
 	return nil, generic.ConfigureApplyForObject(a.apply, obj, &a.opts).
 		WithOwner(obj).
@@ -150,12 +156,36 @@ func (a *persistentVolumeClaimGeneratingHandler) Handle(obj *v1.PersistentVolume
 	}
 
 	objs, newStatus, err := a.PersistentVolumeClaimGeneratingHandler(obj, status)
-	if err != nil {
+	if err != nil || !a.isNewResourceVersion(obj) {
 		return newStatus, err
 	}
 
-	return newStatus, generic.ConfigureApplyForObject(a.apply, obj, &a.opts).
+	err = generic.ConfigureApplyForObject(a.apply, obj, &a.opts).
 		WithOwner(obj).
 		WithSetID(a.name).
 		ApplyObjects(objs...)
+	if err == nil {
+		a.seenResourceVersion(obj)
+	}
+	return newStatus, err
+}
+
+func (a *persistentVolumeClaimGeneratingHandler) isNewResourceVersion(obj *v1.PersistentVolumeClaim) bool {
+	if !a.opts.UniqueApplyForResourceVersion {
+		return true
+	}
+
+	// Apply once per resource version
+	key := obj.Namespace + "/" + obj.Name
+	previous, ok := a.seen.Load(key)
+	return !ok || previous != obj.ResourceVersion
+}
+
+func (a *persistentVolumeClaimGeneratingHandler) seenResourceVersion(obj *v1.PersistentVolumeClaim) {
+	if !a.opts.UniqueApplyForResourceVersion {
+		return
+	}
+
+	key := obj.Namespace + "/" + obj.Name
+	a.seen.Store(key, obj.ResourceVersion)
 }

--- a/pkg/generated/controllers/core/v1/persistentvolumeclaim.go
+++ b/pkg/generated/controllers/core/v1/persistentvolumeclaim.go
@@ -156,18 +156,22 @@ func (a *persistentVolumeClaimGeneratingHandler) Handle(obj *v1.PersistentVolume
 	}
 
 	objs, newStatus, err := a.PersistentVolumeClaimGeneratingHandler(obj, status)
-	if err != nil || !a.isNewResourceVersion(obj) {
+	if err != nil {
 		return newStatus, err
+	}
+	if !a.isNewResourceVersion(obj) {
+		return newStatus, nil
 	}
 
 	err = generic.ConfigureApplyForObject(a.apply, obj, &a.opts).
 		WithOwner(obj).
 		WithSetID(a.name).
 		ApplyObjects(objs...)
-	if err == nil {
-		a.seenResourceVersion(obj)
+	if err != nil {
+		return newStatus, err
 	}
-	return newStatus, err
+	a.storeResourceVersion(obj)
+	return newStatus, nil
 }
 
 func (a *persistentVolumeClaimGeneratingHandler) isNewResourceVersion(obj *v1.PersistentVolumeClaim) bool {
@@ -181,7 +185,7 @@ func (a *persistentVolumeClaimGeneratingHandler) isNewResourceVersion(obj *v1.Pe
 	return !ok || previous != obj.ResourceVersion
 }
 
-func (a *persistentVolumeClaimGeneratingHandler) seenResourceVersion(obj *v1.PersistentVolumeClaim) {
+func (a *persistentVolumeClaimGeneratingHandler) storeResourceVersion(obj *v1.PersistentVolumeClaim) {
 	if !a.opts.UniqueApplyForResourceVersion {
 		return
 	}

--- a/pkg/generated/controllers/core/v1/pod.go
+++ b/pkg/generated/controllers/core/v1/pod.go
@@ -20,6 +20,7 @@ package v1
 
 import (
 	"context"
+	"sync"
 	"time"
 
 	"github.com/rancher/wrangler/v2/pkg/apply"
@@ -127,6 +128,7 @@ type podGeneratingHandler struct {
 	opts  generic.GeneratingHandlerOptions
 	gvk   schema.GroupVersionKind
 	name  string
+	seen  sync.Map
 }
 
 func (a *podGeneratingHandler) Remove(key string, obj *v1.Pod) (*v1.Pod, error) {
@@ -137,6 +139,10 @@ func (a *podGeneratingHandler) Remove(key string, obj *v1.Pod) (*v1.Pod, error) 
 	obj = &v1.Pod{}
 	obj.Namespace, obj.Name = kv.RSplit(key, "/")
 	obj.SetGroupVersionKind(a.gvk)
+
+	if a.opts.UniqueApplyForResourceVersion {
+		a.seen.Delete(key)
+	}
 
 	return nil, generic.ConfigureApplyForObject(a.apply, obj, &a.opts).
 		WithOwner(obj).
@@ -150,12 +156,36 @@ func (a *podGeneratingHandler) Handle(obj *v1.Pod, status v1.PodStatus) (v1.PodS
 	}
 
 	objs, newStatus, err := a.PodGeneratingHandler(obj, status)
-	if err != nil {
+	if err != nil || !a.isNewResourceVersion(obj) {
 		return newStatus, err
 	}
 
-	return newStatus, generic.ConfigureApplyForObject(a.apply, obj, &a.opts).
+	err = generic.ConfigureApplyForObject(a.apply, obj, &a.opts).
 		WithOwner(obj).
 		WithSetID(a.name).
 		ApplyObjects(objs...)
+	if err == nil {
+		a.seenResourceVersion(obj)
+	}
+	return newStatus, err
+}
+
+func (a *podGeneratingHandler) isNewResourceVersion(obj *v1.Pod) bool {
+	if !a.opts.UniqueApplyForResourceVersion {
+		return true
+	}
+
+	// Apply once per resource version
+	key := obj.Namespace + "/" + obj.Name
+	previous, ok := a.seen.Load(key)
+	return !ok || previous != obj.ResourceVersion
+}
+
+func (a *podGeneratingHandler) seenResourceVersion(obj *v1.Pod) {
+	if !a.opts.UniqueApplyForResourceVersion {
+		return
+	}
+
+	key := obj.Namespace + "/" + obj.Name
+	a.seen.Store(key, obj.ResourceVersion)
 }

--- a/pkg/generated/controllers/core/v1/service.go
+++ b/pkg/generated/controllers/core/v1/service.go
@@ -20,6 +20,7 @@ package v1
 
 import (
 	"context"
+	"sync"
 	"time"
 
 	"github.com/rancher/wrangler/v2/pkg/apply"
@@ -127,6 +128,7 @@ type serviceGeneratingHandler struct {
 	opts  generic.GeneratingHandlerOptions
 	gvk   schema.GroupVersionKind
 	name  string
+	seen  sync.Map
 }
 
 func (a *serviceGeneratingHandler) Remove(key string, obj *v1.Service) (*v1.Service, error) {
@@ -137,6 +139,10 @@ func (a *serviceGeneratingHandler) Remove(key string, obj *v1.Service) (*v1.Serv
 	obj = &v1.Service{}
 	obj.Namespace, obj.Name = kv.RSplit(key, "/")
 	obj.SetGroupVersionKind(a.gvk)
+
+	if a.opts.UniqueApplyForResourceVersion {
+		a.seen.Delete(key)
+	}
 
 	return nil, generic.ConfigureApplyForObject(a.apply, obj, &a.opts).
 		WithOwner(obj).
@@ -150,12 +156,36 @@ func (a *serviceGeneratingHandler) Handle(obj *v1.Service, status v1.ServiceStat
 	}
 
 	objs, newStatus, err := a.ServiceGeneratingHandler(obj, status)
-	if err != nil {
+	if err != nil || !a.isNewResourceVersion(obj) {
 		return newStatus, err
 	}
 
-	return newStatus, generic.ConfigureApplyForObject(a.apply, obj, &a.opts).
+	err = generic.ConfigureApplyForObject(a.apply, obj, &a.opts).
 		WithOwner(obj).
 		WithSetID(a.name).
 		ApplyObjects(objs...)
+	if err == nil {
+		a.seenResourceVersion(obj)
+	}
+	return newStatus, err
+}
+
+func (a *serviceGeneratingHandler) isNewResourceVersion(obj *v1.Service) bool {
+	if !a.opts.UniqueApplyForResourceVersion {
+		return true
+	}
+
+	// Apply once per resource version
+	key := obj.Namespace + "/" + obj.Name
+	previous, ok := a.seen.Load(key)
+	return !ok || previous != obj.ResourceVersion
+}
+
+func (a *serviceGeneratingHandler) seenResourceVersion(obj *v1.Service) {
+	if !a.opts.UniqueApplyForResourceVersion {
+		return
+	}
+
+	key := obj.Namespace + "/" + obj.Name
+	a.seen.Store(key, obj.ResourceVersion)
 }

--- a/pkg/generated/controllers/extensions/v1beta1/ingress.go
+++ b/pkg/generated/controllers/extensions/v1beta1/ingress.go
@@ -49,10 +49,14 @@ type IngressCache interface {
 	generic.CacheInterface[*v1beta1.Ingress]
 }
 
+// IngressStatusHandler is executed for every added or modified Ingress. Should return the new status to be updated
 type IngressStatusHandler func(obj *v1beta1.Ingress, status v1beta1.IngressStatus) (v1beta1.IngressStatus, error)
 
+// IngressGeneratingHandler is the top-level handler that is executed for every Ingress event. It extends IngressStatusHandler by a returning a slice of child objects to be passed to apply.Apply
 type IngressGeneratingHandler func(obj *v1beta1.Ingress, status v1beta1.IngressStatus) ([]runtime.Object, v1beta1.IngressStatus, error)
 
+// RegisterIngressStatusHandler configures a IngressController to execute a IngressStatusHandler for every events observed.
+// If a non-empty condition is provided, it will be updated in the status conditions for every handler execution
 func RegisterIngressStatusHandler(ctx context.Context, controller IngressController, condition condition.Cond, name string, handler IngressStatusHandler) {
 	statusHandler := &ingressStatusHandler{
 		client:    controller,
@@ -62,6 +66,8 @@ func RegisterIngressStatusHandler(ctx context.Context, controller IngressControl
 	controller.AddGenericHandler(ctx, name, generic.FromObjectHandlerToHandler(statusHandler.sync))
 }
 
+// RegisterIngressGeneratingHandler configures a IngressController to execute a IngressGeneratingHandler for every events observed, passing the returned objects to the provided apply.Apply.
+// If a non-empty condition is provided, it will be updated in the status conditions for every handler execution
 func RegisterIngressGeneratingHandler(ctx context.Context, controller IngressController, apply apply.Apply,
 	condition condition.Cond, name string, handler IngressGeneratingHandler, opts *generic.GeneratingHandlerOptions) {
 	statusHandler := &ingressGeneratingHandler{
@@ -83,6 +89,7 @@ type ingressStatusHandler struct {
 	handler   IngressStatusHandler
 }
 
+// sync is executed on every resource addition or modification. Executes the configured handlers and sends the updated status to the Kubernetes API
 func (a *ingressStatusHandler) sync(key string, obj *v1beta1.Ingress) (*v1beta1.Ingress, error) {
 	if obj == nil {
 		return obj, nil
@@ -131,6 +138,7 @@ type ingressGeneratingHandler struct {
 	seen  sync.Map
 }
 
+// Remove handles the observed deletion of a resource, cascade deleting every associated resource previously applied
 func (a *ingressGeneratingHandler) Remove(key string, obj *v1beta1.Ingress) (*v1beta1.Ingress, error) {
 	if obj != nil {
 		return obj, nil
@@ -150,6 +158,7 @@ func (a *ingressGeneratingHandler) Remove(key string, obj *v1beta1.Ingress) (*v1
 		ApplyObjects()
 }
 
+// Handle executes the configured IngressGeneratingHandler and pass the resulting objects to apply.Apply, finally returning the new status of the resource
 func (a *ingressGeneratingHandler) Handle(obj *v1beta1.Ingress, status v1beta1.IngressStatus) (v1beta1.IngressStatus, error) {
 	if !obj.DeletionTimestamp.IsZero() {
 		return status, nil
@@ -174,6 +183,8 @@ func (a *ingressGeneratingHandler) Handle(obj *v1beta1.Ingress, status v1beta1.I
 	return newStatus, nil
 }
 
+// isNewResourceVersion detects if a specific resource version was already successfully processed.
+// Only used if UniqueApplyForResourceVersion is set in generic.GeneratingHandlerOptions
 func (a *ingressGeneratingHandler) isNewResourceVersion(obj *v1beta1.Ingress) bool {
 	if !a.opts.UniqueApplyForResourceVersion {
 		return true
@@ -185,6 +196,8 @@ func (a *ingressGeneratingHandler) isNewResourceVersion(obj *v1beta1.Ingress) bo
 	return !ok || previous != obj.ResourceVersion
 }
 
+// storeResourceVersion keeps track of the latest resource version of an object for which Apply was executed
+// Only used if UniqueApplyForResourceVersion is set in generic.GeneratingHandlerOptions
 func (a *ingressGeneratingHandler) storeResourceVersion(obj *v1beta1.Ingress) {
 	if !a.opts.UniqueApplyForResourceVersion {
 		return

--- a/pkg/generic/generating.go
+++ b/pkg/generic/generating.go
@@ -10,6 +10,8 @@ type GeneratingHandlerOptions struct {
 	AllowClusterScoped  bool
 	NoOwnerReference    bool
 	DynamicLookup       bool
+	// UniqueApplyForResourceVersion will skip calling apply if the resource version didn't change from the previous execution
+	UniqueApplyForResourceVersion bool
 }
 
 func ConfigureApplyForObject(apply apply.Apply, obj metav1.Object, opts *GeneratingHandlerOptions) apply.Apply {

--- a/pkg/generic/generating_test.go
+++ b/pkg/generic/generating_test.go
@@ -1,0 +1,116 @@
+package generic_test
+
+import (
+	"context"
+	"github.com/rancher/wrangler/v2/pkg/generic"
+	"testing"
+
+	"github.com/golang/mock/gomock"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+
+	"github.com/rancher/wrangler/v2/pkg/apply"
+	fakeapply "github.com/rancher/wrangler/v2/pkg/apply/fake"
+	v1 "github.com/rancher/wrangler/v2/pkg/generated/controllers/core/v1"
+	fake2 "github.com/rancher/wrangler/v2/pkg/generic/fake"
+)
+
+func TestUniqueApplyForResourceVersion(t *testing.T) {
+	const n = 3
+	type args struct {
+		opts *generic.GeneratingHandlerOptions
+	}
+	tests := []struct {
+		name               string
+		args               args
+		expectedApplyCount int
+	}{
+		{
+			name: "disabled",
+			args: args{
+				opts: &generic.GeneratingHandlerOptions{UniqueApplyForResourceVersion: false},
+			},
+			expectedApplyCount: n,
+		},
+		{
+			name: "enabled",
+			args: args{
+				opts: &generic.GeneratingHandlerOptions{UniqueApplyForResourceVersion: true},
+			},
+			expectedApplyCount: 1,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ctrl := gomock.NewController(t)
+			applySpy := &fakeapply.FakeApply{}
+
+			h := setupTestHandler(ctrl, applySpy, tt.args.opts)
+			if h == nil {
+				t.Fatal("error setting up test handler")
+			}
+
+			service := &corev1.Service{
+				ObjectMeta: metav1.ObjectMeta{Name: "testsvc", Namespace: "testns", ResourceVersion: "unchanged"},
+				Spec:       corev1.ServiceSpec{Ports: []corev1.ServicePort{{Name: "http", Protocol: "tcp", Port: 80}}},
+				Status: corev1.ServiceStatus{
+					Conditions: []metav1.Condition{},
+				},
+			}
+			key := service.Namespace + "/" + service.Name
+			for i := 0; i < n; i++ {
+				if _, err := h(key, service); err != nil {
+					t.Error(err)
+				}
+			}
+			if got, want := applySpy.Count, tt.expectedApplyCount; got != want {
+				t.Errorf("Apply calls count = %v, want %v", got, want)
+			}
+
+			service.ResourceVersion = "changed"
+			if _, err := h(key, service); err != nil {
+				t.Error(err)
+			}
+			if got, want := applySpy.Count, tt.expectedApplyCount+1; got != want {
+				t.Errorf("Apply calls count = %v, want %v", got, want)
+			}
+		})
+	}
+}
+
+func setupTestHandler(ctrl *gomock.Controller, apply apply.Apply, opts *generic.GeneratingHandlerOptions) (handler generic.Handler) {
+	const handlerName = "test"
+	controller := fake2.NewMockControllerInterface[*corev1.Service, *corev1.ServiceList](ctrl)
+	controller.EXPECT().GroupVersionKind()
+	controller.EXPECT().OnChange(gomock.Any(), gomock.Any(), gomock.Any())
+	controller.EXPECT().
+		AddGenericHandler(gomock.Any(), gomock.Eq(handlerName), gomock.Any()).
+		Do(func(_ context.Context, _ string, h generic.Handler) {
+			handler = h
+		}).Times(1)
+
+	v1.RegisterServiceGeneratingHandler(context.Background(), controller, apply, "", handlerName,
+		func(svc *corev1.Service, status corev1.ServiceStatus) (objs []runtime.Object, newstatus corev1.ServiceStatus, err error) {
+			return []runtime.Object{serviceToEndpoint(svc)}, status, nil
+		}, opts)
+	return
+}
+
+func serviceToEndpoint(svc *corev1.Service) *corev1.Endpoints {
+	var ports []corev1.EndpointPort
+	for _, port := range svc.Spec.Ports {
+		ports = append(ports, corev1.EndpointPort{
+			Name: port.Name, Port: port.Port, Protocol: port.Protocol, AppProtocol: port.AppProtocol,
+		})
+	}
+	return &corev1.Endpoints{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      svc.Name,
+			Namespace: svc.Namespace,
+		},
+		Subsets: []corev1.EndpointSubset{
+			{Ports: ports},
+		},
+	}
+}

--- a/pkg/generic/generating_test.go
+++ b/pkg/generic/generating_test.go
@@ -17,7 +17,7 @@ import (
 )
 
 func TestUniqueApplyForResourceVersion(t *testing.T) {
-	const n = 3
+	const numOfHandlerCalls = 3
 	type args struct {
 		opts *generic.GeneratingHandlerOptions
 	}
@@ -31,7 +31,7 @@ func TestUniqueApplyForResourceVersion(t *testing.T) {
 			args: args{
 				opts: &generic.GeneratingHandlerOptions{UniqueApplyForResourceVersion: false},
 			},
-			expectedApplyCount: n,
+			expectedApplyCount: numOfHandlerCalls,
 		},
 		{
 			name: "enabled",
@@ -59,7 +59,7 @@ func TestUniqueApplyForResourceVersion(t *testing.T) {
 				},
 			}
 			key := service.Namespace + "/" + service.Name
-			for i := 0; i < n; i++ {
+			for i := 0; i < numOfHandlerCalls; i++ {
 				if _, err := h(key, service); err != nil {
 					t.Error(err)
 				}


### PR DESCRIPTION
Extends `GeneratingHandlerOptions` to allow a new `UniqueApplyForResourceVersion`, which will keep track of the latest resource version for each individual resource that was handled, avoiding subsequent calls to Apply if the first one was successful. The goal is to limit the number of Apply is called with the same inputs, reducing the computation costs. However, this means that handlers must be deterministic, in the sense that they must produce the same object list for the same input resource, hence this option must be carefully enabled on a case by case basis. It has no impact on other users if the option is not enabled.

We have successfully tested this feature on Fleet's Bundle and GitRepo generating handlers (see rancher/fleet#1964 for an example usage), while trying to mitigate the effect of over-firing handlers (we are also working towards the root cause of the over-firing, which may be partially caused by the use of `Enqueue`).

