### PR TITLE
Support multiple base branches with renovate

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -3,7 +3,9 @@
     "github>rancher/renovate-config#release"
   ],
   "baseBranches": [
-    "master"
+    "master",
+    "release-2.1",
+    "release-2.0-untagged"
   ],
   "prHourlyLimit": 2
 }


### PR DESCRIPTION
Continuation of https://github.com/rancher/rancher/issues/44968

Renovate supports the ability to target multiple base branches. It will update the dependencies of those branches separately, so we don't have to backport any dependency fixes. 

More information on this renovate feature can be found here:
https://docs.renovatebot.com/configuration-options/#basebranches