### PR TITLE
Use goimports instead of k8s.io/code-generator

### DIFF
--- a/pkg/controller-gen/args/groupversion.go
+++ b/pkg/controller-gen/args/groupversion.go
@@ -7,9 +7,9 @@ import (
 	"strings"
 
 	"golang.org/x/tools/go/packages"
+	"golang.org/x/tools/imports"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/code-generator/cmd/client-gen/generators/util"
-	"k8s.io/code-generator/cmd/client-gen/path"
 	"k8s.io/gengo/types"
 )
 
@@ -70,7 +70,7 @@ func toVersionType(obj interface{}) (string, *types.Name) {
 	if t.Kind() == reflect.Ptr {
 		t = t.Elem()
 	}
-	pkg := path.Vendorless(t.PkgPath())
+	pkg := imports.VendorlessPath(t.PkgPath())
 	return versionFromPackage(pkg), &types.Name{
 		Package: pkg,
 		Name:    t.Name(),
@@ -118,7 +118,7 @@ func ScanDirectory(pkgPath string) (result []Type, err error) {
 		for i := 0; i < s.NumFields(); i++ {
 			f := s.Field(i)
 			if f.Embedded() && f.Type().String() == "k8s.io/apimachinery/pkg/apis/meta/v1.ObjectMeta" {
-				pkgPath := path.Vendorless(pkgs[0].PkgPath)
+				pkgPath := imports.VendorlessPath(pkgs[0].PkgPath)
 				result = append(result, Type{
 					Package: pkgPath,
 					Version: versionFromPackage(pkgPath),


### PR DESCRIPTION
There is a conflict happens in kubernetes 1.30:

```
go: github.com/k3s-io/k3s/pkg/codegen imports
	github.com/rancher/wrangler/pkg/controller-gen/args imports
	k8s.io/code-generator/cmd/client-gen/path: module k8s.io/code-generator@latest found (v0.30.0, replaced by github.com/k3s-io/kubernetes/staging/src/k8s.io/code-generator@v1.30.0-k3s1), but does not contain package k8s.io/code-generator/cmd/client-gen/path
```

because upstream has removed the path package in 1.30, this fix will mitigate the use of said package and should outputs the same result.