### PR TITLE
 Extend OnRemove to accept WithCondition option

### DIFF
--- a/pkg/generic/controller.go
+++ b/pkg/generic/controller.go
@@ -54,7 +54,7 @@ type ControllerInterface[T RuntimeMetaObject, TList runtime.Object] interface {
 	OnChange(ctx context.Context, name string, sync ObjectHandler[T])
 
 	// OnRemove runs the given object handler when the controller detects a resource was changed.
-	OnRemove(ctx context.Context, name string, sync ObjectHandler[T])
+	OnRemove(ctx context.Context, name string, sync ObjectHandler[T], opts ...OnRemoveOption)
 
 	// Enqueue adds the resource with the given name in the provided namespace to the worker queue of the controller.
 	Enqueue(namespace, name string)
@@ -75,7 +75,7 @@ type NonNamespacedControllerInterface[T RuntimeMetaObject, TList runtime.Object]
 	OnChange(ctx context.Context, name string, sync ObjectHandler[T])
 
 	// OnRemove runs the given object handler when the controller detects a resource was changed.
-	OnRemove(ctx context.Context, name string, sync ObjectHandler[T])
+	OnRemove(ctx context.Context, name string, sync ObjectHandler[T], opts ...OnRemoveOption)
 
 	// Enqueue adds the resource with the given name to the worker queue of the controller.
 	Enqueue(name string)
@@ -244,8 +244,8 @@ func (c *Controller[T, TList]) OnChange(ctx context.Context, name string, sync O
 }
 
 // OnRemove runs the given object handler when the controller detects a resource was changed.
-func (c *Controller[T, TList]) OnRemove(ctx context.Context, name string, sync ObjectHandler[T]) {
-	c.AddGenericHandler(ctx, name, NewRemoveHandler(name, c.Updater(), FromObjectHandlerToHandler(sync)))
+func (c *Controller[T, TList]) OnRemove(ctx context.Context, name string, sync ObjectHandler[T], opts ...OnRemoveOption) {
+	c.AddGenericHandler(ctx, name, NewRemoveHandler(name, c.Updater(), FromObjectHandlerToHandler(sync), opts...))
 }
 
 // Enqueue adds the resource with the given name in the provided namespace to the worker queue of the controller.

--- a/pkg/generic/fake/controller.go
+++ b/pkg/generic/fake/controller.go
@@ -740,15 +740,20 @@ func (mr *MockControllerInterfaceMockRecorder[T, TList]) OnChange(ctx, name, syn
 }
 
 // OnRemove mocks base method.
-func (m *MockControllerInterface[T, TList]) OnRemove(ctx context.Context, name string, sync generic.ObjectHandler[T]) {
+func (m *MockControllerInterface[T, TList]) OnRemove(ctx context.Context, name string, sync generic.ObjectHandler[T], opts ...generic.OnRemoveOption) {
 	m.ctrl.T.Helper()
-	m.ctrl.Call(m, "OnRemove", ctx, name, sync)
+	varargs := []any{ctx, name, sync}
+	for _, a := range opts {
+		varargs = append(varargs, a)
+	}
+	m.ctrl.Call(m, "OnRemove", varargs...)
 }
 
 // OnRemove indicates an expected call of OnRemove.
-func (mr *MockControllerInterfaceMockRecorder[T, TList]) OnRemove(ctx, name, sync any) *gomock.Call {
+func (mr *MockControllerInterfaceMockRecorder[T, TList]) OnRemove(ctx, name, sync any, opts ...any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "OnRemove", reflect.TypeOf((*MockControllerInterface[T, TList])(nil).OnRemove), ctx, name, sync)
+	varargs := append([]any{ctx, name, sync}, opts...)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "OnRemove", reflect.TypeOf((*MockControllerInterface[T, TList])(nil).OnRemove), varargs...)
 }
 
 // Patch mocks base method.
@@ -1030,15 +1035,20 @@ func (mr *MockNonNamespacedControllerInterfaceMockRecorder[T, TList]) OnChange(c
 }
 
 // OnRemove mocks base method.
-func (m *MockNonNamespacedControllerInterface[T, TList]) OnRemove(ctx context.Context, name string, sync generic.ObjectHandler[T]) {
+func (m *MockNonNamespacedControllerInterface[T, TList]) OnRemove(ctx context.Context, name string, sync generic.ObjectHandler[T], opts ...generic.OnRemoveOption) {
 	m.ctrl.T.Helper()
-	m.ctrl.Call(m, "OnRemove", ctx, name, sync)
+	varargs := []any{ctx, name, sync}
+	for _, a := range opts {
+		varargs = append(varargs, a)
+	}
+	m.ctrl.Call(m, "OnRemove", varargs...)
 }
 
 // OnRemove indicates an expected call of OnRemove.
-func (mr *MockNonNamespacedControllerInterfaceMockRecorder[T, TList]) OnRemove(ctx, name, sync any) *gomock.Call {
+func (mr *MockNonNamespacedControllerInterfaceMockRecorder[T, TList]) OnRemove(ctx, name, sync any, opts ...any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "OnRemove", reflect.TypeOf((*MockNonNamespacedControllerInterface[T, TList])(nil).OnRemove), ctx, name, sync)
+	varargs := append([]any{ctx, name, sync}, opts...)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "OnRemove", reflect.TypeOf((*MockNonNamespacedControllerInterface[T, TList])(nil).OnRemove), varargs...)
 }
 
 // Patch mocks base method.

--- a/pkg/generic/remove_options.go
+++ b/pkg/generic/remove_options.go
@@ -5,7 +5,8 @@ import "k8s.io/apimachinery/pkg/runtime"
 // OnRemoveOption allows configuring OnRemove handlers
 type OnRemoveOption func(*objectLifecycleAdapter)
 
-// WithCondition will make OnRemove handlers to ignore resources not matching the provided condition
+// WithCondition will make OnRemove handlers to ignore resources not matching the provided condition.
+// Successive WithCondition options will replace previous ones; combining conditions needs to be done in the function being passed.
 func WithCondition(f func(runtime.Object) bool) OnRemoveOption {
 	return func(o *objectLifecycleAdapter) {
 		o.condition = f

--- a/pkg/generic/remove_options.go
+++ b/pkg/generic/remove_options.go
@@ -1,0 +1,17 @@
+package generic
+
+import "k8s.io/apimachinery/pkg/runtime"
+
+// OnRemoveOption allows configuring OnRemove handlers
+type OnRemoveOption func(*objectLifecycleAdapter)
+
+// WithCondition will make OnRemove handlers to ignore resources not matching the provided condition
+func WithCondition(f func(runtime.Object) bool) OnRemoveOption {
+	return func(o *objectLifecycleAdapter) {
+		o.condition = f
+	}
+}
+
+func includeAll(_ runtime.Object) bool {
+	return true
+}

--- a/pkg/generic/remove_test.go
+++ b/pkg/generic/remove_test.go
@@ -1,0 +1,150 @@
+package generic
+
+import (
+	"fmt"
+	"testing"
+	"time"
+
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/meta"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+)
+
+func Test_objectLifecycleAdapter_sync(t *testing.T) {
+	const handlerName = "test"
+	type fields struct {
+		opts []OnRemoveOption
+	}
+	type args struct {
+		key string
+		obj runtime.Object
+	}
+	tests := []struct {
+		name             string
+		fields           fields
+		args             args
+		wantErr          bool
+		wantFunc         func(runtime.Object) error
+		wantHandlerCount int
+		wantUpdaterCount int
+	}{
+		// TODO: Add test cases.
+		{
+			name: "nil object",
+			args: args{
+				"objectkey", nil,
+			},
+			wantFunc: func(obj runtime.Object) error {
+				if obj != nil {
+					return fmt.Errorf("obj should be nil")
+				}
+				return nil
+			},
+		},
+		{
+			name: "new object",
+			args: args{
+				"test/service", &corev1.Service{
+					ObjectMeta: metav1.ObjectMeta{Namespace: "test", Name: "service"},
+				},
+			},
+			wantUpdaterCount: 1, // update to add finalizer
+		},
+		{
+			name: "existing object with finalizer",
+			args: args{
+				"test/service", &corev1.Service{
+					ObjectMeta: metav1.ObjectMeta{
+						Namespace: "test", Name: "service",
+						Finalizers: []string{"finalizer", finalizerKey + handlerName},
+					},
+				},
+			},
+			wantUpdaterCount: 0, // finalizer already set, no need to update
+		},
+		{
+			name: "deleted object with finalizer",
+			args: args{
+				key: "test/service", obj: &corev1.Service{
+					ObjectMeta: metav1.ObjectMeta{
+						Namespace: "test", Name: "service",
+						Finalizers:        []string{"finalizer", finalizerKey + handlerName},
+						DeletionTimestamp: &metav1.Time{Time: time.Now()},
+					},
+				},
+			},
+			wantHandlerCount: 1,
+			wantUpdaterCount: 1, // update removing finalizer
+		},
+		{
+			name: "deleted object without finalizer",
+			args: args{
+				key: "test/service", obj: &corev1.Service{
+					ObjectMeta: metav1.ObjectMeta{
+						Namespace: "test", Name: "service",
+						DeletionTimestamp: &metav1.Time{Time: time.Now()},
+					},
+				},
+			},
+			wantHandlerCount: 0,
+			wantUpdaterCount: 0,
+		},
+		{
+			name: "using condition to ignore resource",
+			fields: fields{
+				opts: []OnRemoveOption{
+					WithCondition(func(obj runtime.Object) bool {
+						metadata, err := meta.Accessor(obj)
+						if err != nil {
+							return false
+						}
+						if metadata.GetNamespace() == "test" && metadata.GetName() == "service" {
+							return false
+						}
+						return true
+					})},
+			},
+			args: args{
+				key: "test/service", obj: &corev1.Service{
+					ObjectMeta: metav1.ObjectMeta{
+						Namespace: "test", Name: "service",
+					},
+				},
+			},
+			wantHandlerCount: 0,
+			wantUpdaterCount: 0,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var handlerCount, updaterCount int
+			updater := func(obj runtime.Object) (runtime.Object, error) {
+				updaterCount++
+				return obj, nil
+			}
+			handler := func(key string, obj runtime.Object) (runtime.Object, error) {
+				handlerCount++
+				return obj, nil
+			}
+
+			sync := NewRemoveHandler("test", updater, handler, tt.fields.opts...)
+			got, err := sync(tt.args.key, tt.args.obj)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("sync() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+			if tt.wantFunc != nil {
+				if err := tt.wantFunc(got); err != nil {
+					t.Errorf("sync() unexpected value = %v, err: %v", got, err)
+				}
+			}
+			if got, want := handlerCount, tt.wantHandlerCount; got != want {
+				t.Errorf("handlerCount = %v, want %v", got, want)
+			}
+			if got, want := updaterCount, tt.wantUpdaterCount; got != want {
+				t.Errorf("updaterCount = %v, want %v", got, want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Issue: rancher/rancher#47045
### Needs
- #468 

Please use the [commits view](https://github.com/rancher/wrangler/pull/472/commits) while reviewing this.

### Description
This changes the signature for `OnRemove` to add an optional `OnRemoveOption`s list, which keeps backwards compatibility with existing code (with the exception of possible mocks, which will need to be regenerated).

The new `WithCondition` option accepts a `func(runtime.Object) bool` (defaults to `includeAll`) so that finalizers will only be applied to resources matching the condition.