### PR TITLE
Adjust go.mod values for go/toolchain

### DIFF
--- a/.golangci.json
+++ b/.golangci.json
@@ -12,20 +12,26 @@
     },
     "linters-settings": {
         "govet": {
-            "check-shadowing": false
+            "disable": [
+                "shadow"
+            ]
         },
         "revive": {
-            "rules": {
-                "name": "confusing-naming",
-                "disabled": true
-            }
+            "rules": [
+                {
+                    "name": "confusing-naming",
+                    "disabled": true
+                }
+            ]
         }
     },
     "run": {
-        "skip-dirs": [
-            "pkg/generated"
-        ],
         "tests": false,
         "timeout": "10m"
+    },
+    "issues": {
+        "exclude-dirs": [
+            "pkg/generated"
+        ]
     }
 }

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,8 @@
 module github.com/rancher/wrangler/v3
 
-go 1.23.3
+go 1.23.0
+
+toolchain go1.23.4
 
 require (
 	github.com/evanphx/json-patch v5.9.0+incompatible


### PR DESCRIPTION
When updating BRO for 1.32, I found that the current config caused the CI to be brittle as it required a specific GO 1.23 release. Specifically the error I was encountering is:

>  go.mod requires go >= 1.23.3 (running go 1.23.2; GOTOOLCHAIN=local)

This change should allow for `1.23.2` (and older 1.23) to work without errors.