### PR TITLE
Add override for MicroTime to "date" 

### DIFF
--- a/pkg/schemas/reflection.go
+++ b/pkg/schemas/reflection.go
@@ -496,6 +496,9 @@ func (s *Schemas) determineSchemaType(t reflect.Type) (string, error) {
 		if t.Name() == "Time" {
 			return "date", nil
 		}
+		if t.Name() == "MicroTime" {
+			return "date", nil
+		}
 		if t.Name() == "IntOrString" {
 			return "intOrString", nil
 		}


### PR DESCRIPTION
This PR adds a type override for "MicroTime" fields, correctly identifying them as "date" for later OpenAPI spec gen.

This fixes #513 