### PR TITLE
Add Opt-In KEP-1623 support for existing Conditions

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -26,6 +26,7 @@ require (
 	k8s.io/kube-aggregator v0.32.1
 	k8s.io/kube-openapi v0.0.0-20241105132330-32ad38e42d3f
 	sigs.k8s.io/cli-utils v0.37.2
+	sigs.k8s.io/controller-runtime v0.18.4
 )
 
 require (
@@ -38,6 +39,7 @@ require (
 	github.com/cespare/xxhash/v2 v2.3.0 // indirect
 	github.com/davecgh/go-spew v1.1.2-0.20180830191138-d8f796af33cc // indirect
 	github.com/emicklei/go-restful/v3 v3.12.1 // indirect
+	github.com/evanphx/json-patch/v5 v5.9.0 // indirect
 	github.com/felixge/httpsnoop v1.0.4 // indirect
 	github.com/fxamacker/cbor/v2 v2.7.0 // indirect
 	github.com/go-logr/logr v1.4.2 // indirect

--- a/go.sum
+++ b/go.sum
@@ -25,6 +25,8 @@ github.com/emicklei/go-restful/v3 v3.12.1 h1:PJMDIM/ak7btuL8Ex0iYET9hxM3CI2sjZtz
 github.com/emicklei/go-restful/v3 v3.12.1/go.mod h1:6n3XBCmQQb25CM2LCACGz8ukIrRry+4bhvbpWn3mrbc=
 github.com/evanphx/json-patch v5.9.11+incompatible h1:ixHHqfcGvxhWkniF1tWxBHA0yb4Z+d1UQi45df52xW8=
 github.com/evanphx/json-patch v5.9.11+incompatible/go.mod h1:50XU6AFN0ol/bzJsmQLiYLvXMP4fmwYFNcr97nuDLSk=
+github.com/evanphx/json-patch/v5 v5.9.0 h1:kcBlZQbplgElYIlo/n1hJbls2z/1awpXxpRi0/FOJfg=
+github.com/evanphx/json-patch/v5 v5.9.0/go.mod h1:VNkHZ/282BpEyt/tObQO8s5CMPmYYq14uClGH4abBuQ=
 github.com/felixge/httpsnoop v1.0.4 h1:NFTV2Zj1bL4mc9sqWACXbQFVBBg2W3GPvqp8/ESS2Wg=
 github.com/felixge/httpsnoop v1.0.4/go.mod h1:m8KPJKqk1gH5J9DgRY2ASl2lWCfGKXixSwevea8zH2U=
 github.com/fxamacker/cbor/v2 v2.7.0 h1:iM5WgngdRBanHcxugY4JySA0nk1wZorNOpTgCMedv5E=
@@ -277,6 +279,8 @@ sigs.k8s.io/apiserver-network-proxy/konnectivity-client v0.31.0 h1:CPT0ExVicCzcp
 sigs.k8s.io/apiserver-network-proxy/konnectivity-client v0.31.0/go.mod h1:Ve9uj1L+deCXFrPOk1LpFXqTg7LCFzFso6PA48q/XZw=
 sigs.k8s.io/cli-utils v0.37.2 h1:GOfKw5RV2HDQZDJlru5KkfLO1tbxqMoyn1IYUxqBpNg=
 sigs.k8s.io/cli-utils v0.37.2/go.mod h1:V+IZZr4UoGj7gMJXklWBg6t5xbdThFBcpj4MrZuCYco=
+sigs.k8s.io/controller-runtime v0.18.4 h1:87+guW1zhvuPLh1PHybKdYFLU0YJp4FhJRmiHvm5BZw=
+sigs.k8s.io/controller-runtime v0.18.4/go.mod h1:TVoGrfdpbA9VRFaRnKgk9P5/atA0pMwq+f+msb9M8Sg=
 sigs.k8s.io/json v0.0.0-20241010143419-9aa6b5e7a4b3 h1:/Rv+M11QRah1itp8VhT6HoVx1Ray9eB4DBr+K+/sCJ8=
 sigs.k8s.io/json v0.0.0-20241010143419-9aa6b5e7a4b3/go.mod h1:18nIHnGi6636UCz6m8i4DhaJ65T6EruyzmoQqI2BVDo=
 sigs.k8s.io/structured-merge-diff/v4 v4.4.3 h1:sCP7Vv3xx/CWIuTPVN38lUPx0uw0lcLfzaiDa8Ja01A=

--- a/pkg/condition/condition.go
+++ b/pkg/condition/condition.go
@@ -160,7 +160,7 @@ func (c Cond) Name() string {
 	return string(c)
 }
 
-func (c Cond) ToKatesCondition() types.Condition {
+func (c Cond) ToK8sCondition() types.Condition {
 	return &MetaV1ConditionHandler{
 		RootCondition: c,
 	}

--- a/pkg/condition/condition.go
+++ b/pkg/condition/condition.go
@@ -166,6 +166,18 @@ func (c Cond) ToK8sCondition() types.Condition {
 	}
 }
 
+func (c Cond) ToFluentBuilder(obj interface{}) types.FluentCondition {
+	if obj != nil {
+		handler := MetaV1ConditionFluentBuilder{
+			RootCondition: c,
+		}
+		return handler.Target(obj)
+	}
+	return &MetaV1ConditionFluentBuilder{
+		RootCondition: c,
+	}
+}
+
 func touchTS(value reflect.Value) {
 	now := time.Now().UTC().Format(time.RFC3339)
 	getFieldValue(value, "LastUpdateTime").SetString(now)

--- a/pkg/condition/condition.go
+++ b/pkg/condition/condition.go
@@ -3,6 +3,7 @@ package condition
 import (
 	"github.com/rancher/wrangler/v3/pkg/condition/types"
 	"reflect"
+	"sigs.k8s.io/controller-runtime/pkg/client"
 	"time"
 
 	"github.com/sirupsen/logrus"
@@ -166,7 +167,7 @@ func (c Cond) ToK8sCondition() types.Condition {
 	}
 }
 
-func (c Cond) ToFluentBuilder(obj interface{}) types.FluentCondition {
+func (c Cond) ToFluentBuilder(obj client.Object) types.FluentCondition {
 	if obj != nil {
 		handler := MetaV1ConditionFluentBuilder{
 			RootCondition: c,

--- a/pkg/condition/condition.go
+++ b/pkg/condition/condition.go
@@ -4,11 +4,26 @@ import (
 	"reflect"
 	"time"
 
-	"github.com/rancher/wrangler/v3/pkg/generic"
 	"github.com/sirupsen/logrus"
+
+	"github.com/rancher/wrangler/v3/pkg/generic"
 )
 
 type Cond string
+
+func (c Cond) HasCondition(obj interface{}) bool {
+	condSlice := getValue(obj, "Status", "Conditions")
+	if !condSlice.IsValid() {
+		condSlice = getValue(obj, "Conditions")
+	}
+
+	foundCond := findCond(obj, condSlice, string(c))
+	if foundCond != nil {
+		return true
+	}
+
+	return false
+}
 
 func (c Cond) GetStatus(obj interface{}) string {
 	return getStatus(obj, string(c))

--- a/pkg/condition/condition_test.go
+++ b/pkg/condition/condition_test.go
@@ -1,0 +1,164 @@
+package condition
+
+import (
+	"github.com/rancher/wrangler/v3/pkg/genericcondition"
+	"github.com/stretchr/testify/assert"
+	"testing"
+)
+
+type testObjStatus struct {
+	Conditions []genericcondition.GenericCondition `json:"conditions"`
+}
+
+type testResourceObj struct {
+	Status testObjStatus `json:"status"`
+}
+
+func newTestObj(conditions ...Cond) testResourceObj {
+	newObj := testResourceObj{
+		Status: testObjStatus{
+			Conditions: []genericcondition.GenericCondition{},
+		},
+	}
+	if len(conditions) > 0 {
+		for _, condition := range conditions {
+			condition.SetStatusBool(&newObj, true)
+			condition.Message(&newObj, "Hello World")
+		}
+	}
+
+	return newObj
+}
+
+const (
+	TestCondtion        Cond = "Test"
+	AnotherTestCondtion Cond = "SecondTest"
+)
+
+func TestGetStatus(t *testing.T) {
+	testObj := newTestObj(TestCondtion)
+	assert.Equal(t, "True", TestCondtion.GetStatus(&testObj))
+	assert.Equal(t, "True", TestCondtion.GetStatus(&testObj.Status))
+
+	assert.Equal(t, "", AnotherTestCondtion.GetStatus(&testObj))
+	assert.Equal(t, "", AnotherTestCondtion.GetStatus(&testObj.Status))
+}
+
+func TestSetStatus(t *testing.T) {
+	testObj := newTestObj(TestCondtion)
+	assert.Equal(t, "True", TestCondtion.GetStatus(&testObj))
+	assert.Equal(t, "True", TestCondtion.GetStatus(&testObj.Status))
+	TestCondtion.SetStatus(&testObj, "False")
+	assert.Equal(t, "False", TestCondtion.GetStatus(&testObj))
+	assert.Equal(t, "False", TestCondtion.GetStatus(&testObj.Status))
+
+	assert.Equal(t, "", AnotherTestCondtion.GetStatus(&testObj))
+	assert.Equal(t, "", AnotherTestCondtion.GetStatus(&testObj.Status))
+	AnotherTestCondtion.SetStatus(&testObj, "Unknown")
+	assert.Equal(t, "Unknown", AnotherTestCondtion.GetStatus(&testObj))
+	assert.Equal(t, "Unknown", AnotherTestCondtion.GetStatus(&testObj.Status))
+}
+
+func TestSetStatusBool(t *testing.T) {
+	testObj := newTestObj(TestCondtion)
+	assert.Equal(t, "True", TestCondtion.GetStatus(&testObj))
+	assert.Equal(t, "True", TestCondtion.GetStatus(&testObj.Status))
+	TestCondtion.SetStatusBool(&testObj, false)
+	assert.Equal(t, "False", TestCondtion.GetStatus(&testObj))
+	assert.Equal(t, "False", TestCondtion.GetStatus(&testObj.Status))
+
+	assert.Equal(t, "", AnotherTestCondtion.GetStatus(&testObj))
+	assert.Equal(t, "", AnotherTestCondtion.GetStatus(&testObj.Status))
+	AnotherTestCondtion.SetStatusBool(&testObj, true)
+	assert.Equal(t, "True", AnotherTestCondtion.GetStatus(&testObj))
+	assert.Equal(t, "True", AnotherTestCondtion.GetStatus(&testObj.Status))
+}
+
+func TestBoolHelpers(t *testing.T) {
+	testObj := newTestObj(TestCondtion)
+	assert.Equal(t, "True", TestCondtion.GetStatus(&testObj))
+	assert.Equal(t, "True", TestCondtion.GetStatus(&testObj.Status))
+	TestCondtion.False(&testObj)
+	assert.Equal(t, "False", TestCondtion.GetStatus(&testObj))
+	assert.Equal(t, "False", TestCondtion.GetStatus(&testObj.Status))
+
+	assert.Equal(t, "", AnotherTestCondtion.GetStatus(&testObj))
+	assert.Equal(t, "", AnotherTestCondtion.GetStatus(&testObj.Status))
+	AnotherTestCondtion.True(&testObj)
+	assert.Equal(t, "True", AnotherTestCondtion.GetStatus(&testObj))
+	assert.Equal(t, "True", AnotherTestCondtion.GetStatus(&testObj.Status))
+	AnotherTestCondtion.False(&testObj)
+	assert.Equal(t, "False", AnotherTestCondtion.GetStatus(&testObj))
+	assert.Equal(t, "False", AnotherTestCondtion.GetStatus(&testObj.Status))
+}
+
+func TestBoolConditoins(t *testing.T) {
+	testObj := newTestObj(TestCondtion)
+	assert.True(t, TestCondtion.IsTrue(&testObj))
+	assert.True(t, TestCondtion.IsTrue(&testObj.Status))
+	TestCondtion.False(&testObj)
+	assert.True(t, TestCondtion.IsFalse(&testObj))
+	assert.True(t, TestCondtion.IsFalse(&testObj.Status))
+
+	assert.Equal(t, "", AnotherTestCondtion.GetStatus(&testObj))
+	assert.Equal(t, "", AnotherTestCondtion.GetStatus(&testObj.Status))
+	AnotherTestCondtion.True(&testObj)
+	assert.True(t, AnotherTestCondtion.IsTrue(&testObj))
+	assert.True(t, AnotherTestCondtion.IsTrue(&testObj.Status))
+	AnotherTestCondtion.False(&testObj)
+	assert.True(t, AnotherTestCondtion.IsFalse(&testObj))
+	assert.True(t, AnotherTestCondtion.IsFalse(&testObj.Status))
+}
+
+func TestUnknownHelpers(t *testing.T) {
+	testObj := newTestObj(TestCondtion)
+	assert.False(t, TestCondtion.IsUnknown(&testObj))
+	assert.False(t, AnotherTestCondtion.IsUnknown(&testObj))
+	AnotherTestCondtion.Message(&testObj, "Test Message, will default status to unknown")
+	assert.True(t, AnotherTestCondtion.IsUnknown(&testObj))
+
+	TestCondtion.Unknown(&testObj)
+	assert.True(t, TestCondtion.IsUnknown(&testObj))
+}
+
+func TestCreateUnknownIfNotExists(t *testing.T) {
+	testObj := newTestObj(TestCondtion)
+	assert.False(t, TestCondtion.IsUnknown(&testObj))
+	assert.False(t, AnotherTestCondtion.IsUnknown(&testObj))
+	AnotherTestCondtion.CreateUnknownIfNotExists(&testObj)
+	assert.True(t, AnotherTestCondtion.IsUnknown(&testObj))
+	TestCondtion.CreateUnknownIfNotExists(&testObj)
+	assert.False(t, TestCondtion.IsUnknown(&testObj))
+}
+
+func TestReasonMethods(t *testing.T) {
+	testObj := newTestObj(TestCondtion)
+	TestCondtion.Reason(&testObj, "Because I Said So")
+	assert.Equal(t, "Because I Said So", TestCondtion.GetReason(&testObj))
+
+	assert.Equal(t, "", AnotherTestCondtion.GetReason(&testObj))
+	AnotherTestCondtion.Reason(&testObj, "Because Tom Said So")
+	assert.Equal(t, "Because Tom Said So", AnotherTestCondtion.GetReason(&testObj))
+}
+
+func TestSetMessageIfBlank(t *testing.T) {
+	testObj := newTestObj(TestCondtion)
+	TestCondtion.SetMessageIfBlank(&testObj, "This will be ignored")
+	assert.NotEqual(t, "This will be ignored", TestCondtion.GetMessage(&testObj))
+
+	assert.Equal(t, "", AnotherTestCondtion.GetMessage(&testObj))
+	AnotherTestCondtion.SetMessageIfBlank(&testObj, "This will be updated")
+	assert.Equal(t, "This will be updated", AnotherTestCondtion.GetMessage(&testObj))
+	AnotherTestCondtion.SetMessageIfBlank(&testObj, "This will NOT be updated")
+	assert.Equal(t, "This will be updated", AnotherTestCondtion.GetMessage(&testObj))
+}
+
+func TestMessageMethods(t *testing.T) {
+	testObj := newTestObj(TestCondtion)
+	assert.Equal(t, "Hello World", TestCondtion.GetMessage(&testObj))
+	TestCondtion.Message(&testObj, "")
+	assert.Equal(t, "", TestCondtion.GetMessage(&testObj))
+
+	AnotherTestCondtion.Message(&testObj, "This will be updated")
+	assert.Equal(t, "This will be updated", AnotherTestCondtion.GetMessage(&testObj))
+}

--- a/pkg/condition/condition_test.go
+++ b/pkg/condition/condition_test.go
@@ -35,6 +35,15 @@ const (
 	AnotherTestCondtion Cond = "SecondTest"
 )
 
+func TestHasCondition(t *testing.T) {
+	testObj := newTestObj(TestCondtion)
+	assert.Equal(t, true, TestCondtion.HasCondition(&testObj))
+	assert.Equal(t, true, TestCondtion.HasCondition(&testObj.Status))
+
+	assert.Equal(t, false, AnotherTestCondtion.HasCondition(&testObj))
+	assert.Equal(t, false, AnotherTestCondtion.HasCondition(&testObj.Status))
+}
+
 func TestGetStatus(t *testing.T) {
 	testObj := newTestObj(TestCondtion)
 	assert.Equal(t, "True", TestCondtion.GetStatus(&testObj))

--- a/pkg/condition/fluent.go
+++ b/pkg/condition/fluent.go
@@ -7,6 +7,7 @@ import (
 	"github.com/sirupsen/logrus"
 	"k8s.io/apimachinery/pkg/api/meta"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
 type MetaV1ConditionFluentBuilder struct {
@@ -15,7 +16,7 @@ type MetaV1ConditionFluentBuilder struct {
 	workingCondition metav1.Condition
 }
 
-func (m *MetaV1ConditionFluentBuilder) Target(obj interface{}) types.FluentCondition {
+func (m *MetaV1ConditionFluentBuilder) Target(obj client.Object) types.FluentCondition {
 	cond := m.findOrInitCond(obj)
 	m.workingCondition = *cond.DeepCopy()
 	m.initedTarget = true
@@ -23,7 +24,7 @@ func (m *MetaV1ConditionFluentBuilder) Target(obj interface{}) types.FluentCondi
 	return m
 }
 
-func (m *MetaV1ConditionFluentBuilder) findOrInitCond(obj interface{}) metav1.Condition {
+func (m *MetaV1ConditionFluentBuilder) findOrInitCond(obj client.Object) metav1.Condition {
 	foundCondition := findCondition(obj, m.RootCondition.Name())
 	if foundCondition != nil {
 		return *foundCondition
@@ -138,7 +139,7 @@ func (m *MetaV1ConditionFluentBuilder) SetMessageIfBlank(message string) types.F
 	return m
 }
 
-func (m *MetaV1ConditionFluentBuilder) Apply(obj interface{}) bool {
+func (m *MetaV1ConditionFluentBuilder) Apply(obj client.Object) bool {
 	if !m.initedTarget {
 		logrus.Warnf("fluent condition handler not initialized")
 		return false

--- a/pkg/condition/fluent.go
+++ b/pkg/condition/fluent.go
@@ -146,6 +146,7 @@ func (m *MetaV1ConditionFluentBuilder) Apply(obj interface{}) bool {
 
 	conditionsSlice, ok := getConditionsSlice(obj)
 	if ok {
+		m.workingCondition.ObservedGeneration = getResourceGeneration(obj)
 		changed := meta.SetStatusCondition(&conditionsSlice, m.workingCondition)
 		m.initedTarget = false
 		m.workingCondition = metav1.Condition{}

--- a/pkg/condition/fluent.go
+++ b/pkg/condition/fluent.go
@@ -1,0 +1,159 @@
+package condition
+
+import (
+	"errors"
+	"github.com/rancher/wrangler/v3/pkg/condition/types"
+	"github.com/rancher/wrangler/v3/pkg/generic"
+	"github.com/sirupsen/logrus"
+	"k8s.io/apimachinery/pkg/api/meta"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+type MetaV1ConditionFluentBuilder struct {
+	RootCondition    Cond
+	initedTarget     bool
+	workingCondition metav1.Condition
+}
+
+func (m *MetaV1ConditionFluentBuilder) Target(obj interface{}) types.FluentCondition {
+	cond := m.findOrInitCond(obj)
+	m.workingCondition = *cond.DeepCopy()
+	m.initedTarget = true
+
+	return m
+}
+
+func (m *MetaV1ConditionFluentBuilder) findOrInitCond(obj interface{}) metav1.Condition {
+	foundCondition := findCondition(obj, m.RootCondition.Name())
+	if foundCondition != nil {
+		return *foundCondition
+	}
+
+	return metav1.Condition{
+		Type:    m.RootCondition.Name(),
+		Status:  metav1.ConditionUnknown,
+		Reason:  "Created",
+		Message: "",
+	}
+}
+
+func (m *MetaV1ConditionFluentBuilder) SetStatus(status string) types.FluentCondition {
+	if !m.initedTarget {
+		logrus.Warnf("fluent condition handler not initialized")
+		return m
+	}
+
+	if status != string(metav1.ConditionTrue) &&
+		status != string(metav1.ConditionFalse) &&
+		status != string(metav1.ConditionUnknown) {
+		panic("unknown condition status: " + status)
+	}
+
+	m.workingCondition.Status = metav1.ConditionStatus(status)
+
+	return m
+}
+
+func (m *MetaV1ConditionFluentBuilder) True() types.FluentCondition {
+	m.SetStatus("True")
+	return m
+}
+
+func (m *MetaV1ConditionFluentBuilder) False() types.FluentCondition {
+	m.SetStatus("False")
+	return m
+}
+
+func (m *MetaV1ConditionFluentBuilder) Unknown() types.FluentCondition {
+	m.SetStatus("Unknown")
+	return m
+}
+
+func (m *MetaV1ConditionFluentBuilder) SetStatusBool(val bool) types.FluentCondition {
+	if val {
+		m.SetStatus("True")
+	} else {
+		m.SetStatus("False")
+	}
+
+	return m
+}
+
+func (m *MetaV1ConditionFluentBuilder) SetError(reason string, err error) types.FluentCondition {
+	if !m.initedTarget {
+		logrus.Warnf("fluent condition handler not initialized")
+		return m
+	}
+
+	if err == nil || errors.Is(err, generic.ErrSkip) {
+		m.workingCondition.Status = metav1.ConditionTrue
+		m.workingCondition.Message = ""
+		m.workingCondition.Reason = reason
+
+		return m
+	}
+
+	if reason == "" {
+		reason = "Error"
+	}
+
+	m.workingCondition.Status = metav1.ConditionFalse
+	m.workingCondition.Message = err.Error()
+	m.workingCondition.Reason = reason
+
+	return m
+}
+
+func (m *MetaV1ConditionFluentBuilder) SetReason(reason string) types.FluentCondition {
+	if !m.initedTarget {
+		logrus.Warnf("fluent condition handler not initialized")
+		return m
+	}
+
+	m.workingCondition.Reason = reason
+	return m
+}
+
+func (m *MetaV1ConditionFluentBuilder) SetMessage(message string) types.FluentCondition {
+	if !m.initedTarget {
+		logrus.Warnf("fluent condition handler not initialized")
+		return m
+	}
+
+	m.workingCondition.Message = message
+	return m
+}
+
+func (m *MetaV1ConditionFluentBuilder) SetMessageIfBlank(message string) types.FluentCondition {
+	if !m.initedTarget {
+		logrus.Warnf("fluent condition handler not initialized")
+		return m
+	}
+
+	if m.workingCondition.Message != "" {
+		return m
+	}
+
+	m.workingCondition.Message = message
+	return m
+}
+
+func (m *MetaV1ConditionFluentBuilder) Apply(obj interface{}) bool {
+	if !m.initedTarget {
+		logrus.Warnf("fluent condition handler not initialized")
+		return false
+	}
+
+	conditionsSlice, ok := getConditionsSlice(obj)
+	if ok {
+		changed := meta.SetStatusCondition(&conditionsSlice, m.workingCondition)
+		m.initedTarget = false
+		m.workingCondition = metav1.Condition{}
+		if changed {
+			setConditionsSlice(obj, conditionsSlice)
+		}
+		return changed
+	}
+
+	return false
+}

--- a/pkg/condition/fluent_test.go
+++ b/pkg/condition/fluent_test.go
@@ -1,0 +1,174 @@
+package condition
+
+import (
+	"bytes"
+	"errors"
+	"github.com/rancher/wrangler/v3/pkg/generic"
+	"github.com/sirupsen/logrus"
+	"github.com/stretchr/testify/assert"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"os"
+	"testing"
+)
+
+func TestFluentConditionSetStatus(t *testing.T) {
+	testObj := newTestObjStd(TestCondtion)
+	assert.Equal(t, "True", TestCondtion.ToK8sCondition().GetStatus(&testObj))
+	assert.Equal(t, "True", TestCondtion.ToK8sCondition().GetStatus(&testObj.Status))
+	TestCondtion.ToFluentBuilder(&testObj).SetStatus("False").Apply(&testObj)
+	assert.Equal(t, "False", TestCondtion.ToK8sCondition().GetStatus(&testObj))
+	assert.Equal(t, "False", TestCondtion.ToK8sCondition().GetStatus(&testObj.Status))
+
+	assert.Equal(t, "", AnotherTestCondtion.GetStatus(&testObj))
+	assert.Equal(t, "", AnotherTestCondtion.GetStatus(&testObj.Status))
+	AnotherTestCondtion.ToFluentBuilder(&testObj).SetStatus("Unknown").Apply(&testObj)
+	assert.Equal(t, "Unknown", AnotherTestCondtion.GetStatus(&testObj))
+	assert.Equal(t, "Unknown", AnotherTestCondtion.GetStatus(&testObj.Status))
+}
+
+func TestFluentBoolHelpers(t *testing.T) {
+	testObj := newTestObjStd(TestCondtion)
+
+	assert.Equal(t, "True", TestCondtion.ToK8sCondition().GetStatus(&testObj))
+	assert.Equal(t, "True", TestCondtion.ToK8sCondition().GetStatus(&testObj.Status))
+	TestCondtion.ToFluentBuilder(&testObj).False().Apply(&testObj)
+	assert.Equal(t, "False", TestCondtion.ToK8sCondition().GetStatus(&testObj))
+	assert.Equal(t, "False", TestCondtion.ToK8sCondition().GetStatus(&testObj.Status))
+
+	assert.Equal(t, "", AnotherTestCondtion.ToK8sCondition().GetStatus(&testObj))
+	assert.Equal(t, "", AnotherTestCondtion.ToK8sCondition().GetStatus(&testObj.Status))
+	AnotherTestCondtion.ToFluentBuilder(&testObj).True().Apply(&testObj)
+	assert.Equal(t, "True", AnotherTestCondtion.ToK8sCondition().GetStatus(&testObj))
+	assert.Equal(t, "True", AnotherTestCondtion.ToK8sCondition().GetStatus(&testObj.Status))
+	AnotherTestCondtion.ToFluentBuilder(nil).Target(&testObj).False().Apply(&testObj)
+	assert.Equal(t, "False", AnotherTestCondtion.ToK8sCondition().GetStatus(&testObj))
+	assert.Equal(t, "False", AnotherTestCondtion.ToK8sCondition().GetStatus(&testObj.Status))
+
+	TestCondtion.ToFluentBuilder(&testObj).Unknown().Apply(&testObj)
+	assert.Equal(t, "Unknown", TestCondtion.ToK8sCondition().GetStatus(&testObj))
+	assert.Equal(t, "Unknown", TestCondtion.ToK8sCondition().GetStatus(&testObj.Status))
+}
+
+func TestFluentConditionSetStatusBool(t *testing.T) {
+	testObj := newTestObjStd(TestCondtion)
+	assert.Equal(t, "True", TestCondtion.ToK8sCondition().GetStatus(&testObj))
+	assert.Equal(t, "True", TestCondtion.ToK8sCondition().GetStatus(&testObj.Status))
+	TestCondtion.ToFluentBuilder(&testObj).SetStatusBool(false).Apply(&testObj)
+	assert.Equal(t, "False", TestCondtion.ToK8sCondition().GetStatus(&testObj))
+	assert.Equal(t, "False", TestCondtion.ToK8sCondition().GetStatus(&testObj.Status))
+
+	assert.Equal(t, "", AnotherTestCondtion.ToK8sCondition().GetStatus(&testObj))
+	assert.Equal(t, "", AnotherTestCondtion.ToK8sCondition().GetStatus(&testObj.Status))
+	AnotherTestCondtion.ToFluentBuilder(&testObj).SetStatusBool(true).Apply(&testObj)
+	assert.Equal(t, "True", AnotherTestCondtion.ToK8sCondition().GetStatus(&testObj))
+	assert.Equal(t, "True", AnotherTestCondtion.ToK8sCondition().GetStatus(&testObj.Status))
+}
+
+func TestSetError(t *testing.T) {
+	testObj := newTestObjStd(TestCondtion)
+	testErr := errors.New("test error")
+
+	TestCondtion.ToFluentBuilder(&testObj).SetError("it all broke", testErr).Apply(&testObj)
+	assert.Equal(t, "False", TestCondtion.ToK8sCondition().GetStatus(&testObj))
+	assert.Equal(t, "it all broke", TestCondtion.ToK8sCondition().GetReason(&testObj))
+	assert.Equal(t, "test error", TestCondtion.ToK8sCondition().GetMessage(&testObj))
+
+	testErr = errors.New("another test error")
+	TestCondtion.ToFluentBuilder(&testObj).SetError("", testErr).Apply(&testObj)
+	assert.Equal(t, "False", TestCondtion.ToK8sCondition().GetStatus(&testObj))
+	assert.Equal(t, "Error", TestCondtion.ToK8sCondition().GetReason(&testObj))
+	assert.Equal(t, "another test error", TestCondtion.ToK8sCondition().GetMessage(&testObj))
+
+	TestCondtion.ToFluentBuilder(&testObj).SetError("Skip-itty Skip", generic.ErrSkip).Apply(&testObj)
+	assert.Equal(t, "True", TestCondtion.ToK8sCondition().GetStatus(&testObj))
+	assert.Equal(t, "Skip-itty Skip", TestCondtion.ToK8sCondition().GetReason(&testObj))
+	assert.Equal(t, "", TestCondtion.ToK8sCondition().GetMessage(&testObj))
+}
+
+func TestFluentConditionSetReasonMethods(t *testing.T) {
+	testObj := newTestObjStd(TestCondtion)
+	TestCondtion.ToFluentBuilder(&testObj).SetReason("Because I Said So").Apply(&testObj)
+	assert.Equal(t, "Because I Said So", TestCondtion.ToK8sCondition().GetReason(&testObj))
+
+	assert.Equal(t, "", AnotherTestCondtion.ToK8sCondition().GetReason(&testObj))
+	AnotherTestCondtion.ToFluentBuilder(&testObj).SetReason("Because Tom Said So").Apply(&testObj)
+	assert.Equal(t, "Because Tom Said So", AnotherTestCondtion.ToK8sCondition().GetReason(&testObj))
+}
+
+func TestFluentConditionSetMessage(t *testing.T) {
+	testObj := newTestObjStd(TestCondtion)
+	TestCondtion.ToFluentBuilder(&testObj).SetMessage("This will NOT be ignored").Apply(&testObj)
+	assert.Equal(t, "This will NOT be ignored", TestCondtion.GetMessage(&testObj))
+
+	assert.Equal(t, "", AnotherTestCondtion.GetMessage(&testObj))
+	AnotherTestCondtion.ToFluentBuilder(&testObj).SetMessage("This will be updated").Apply(&testObj)
+	assert.Equal(t, "This will be updated", AnotherTestCondtion.GetMessage(&testObj))
+}
+
+func TestFluentConditionSetMessageIfBlank(t *testing.T) {
+	testObj := newTestObjStd(TestCondtion)
+	TestCondtion.ToFluentBuilder(&testObj).SetMessageIfBlank("This will be ignored").Apply(&testObj)
+	assert.NotEqual(t, "This will be ignored", TestCondtion.GetMessage(&testObj))
+
+	assert.Equal(t, "", AnotherTestCondtion.GetMessage(&testObj))
+	AnotherTestCondtion.ToFluentBuilder(&testObj).SetMessageIfBlank("This will be updated").Apply(&testObj)
+	assert.Equal(t, "This will be updated", AnotherTestCondtion.GetMessage(&testObj))
+	AnotherTestCondtion.ToFluentBuilder(&testObj).SetMessageIfBlank("This will NOT be updated").Apply(&testObj)
+	assert.Equal(t, "This will be updated", AnotherTestCondtion.GetMessage(&testObj))
+}
+
+func TestIncorrectBuilder(t *testing.T) {
+	testObj := newTestObjStd(TestCondtion)
+	fluentBuilder := MetaV1ConditionFluentBuilder{
+		RootCondition: TestCondtion,
+	}
+
+	// Base control expectations
+	assert.Equal(t, "True", TestCondtion.ToK8sCondition().GetStatus(&testObj))
+	assert.False(t, fluentBuilder.initedTarget)
+	assert.Equal(t, metav1.Condition{}, fluentBuilder.workingCondition)
+
+	// Capture logs
+	var logBuf bytes.Buffer
+	logrus.SetOutput(&logBuf)
+	defer logrus.SetOutput(os.Stderr) // reset after test
+
+	// Verify SetStatus
+	fluentBuilder.SetStatus("Unknown")
+	assert.NotEqual(t, "Unknown", TestCondtion.ToK8sCondition().GetStatus(&testObj))
+	assert.Contains(t, logBuf.String(), "fluent condition handler not initialized")
+
+	// Verify SetError
+	logBuf = bytes.Buffer{}
+	assert.Empty(t, logBuf.String())
+	testErr := errors.New("test error")
+	fluentBuilder.SetError("", testErr)
+	assert.Contains(t, logBuf.String(), "fluent condition handler not initialized")
+
+	// Verify SetReason
+	logBuf = bytes.Buffer{}
+	assert.Empty(t, logBuf.String())
+	fluentBuilder.SetReason("for fun")
+	assert.NotEqual(t, "for fun", TestCondtion.ToK8sCondition().GetReason(&testObj))
+	assert.Contains(t, logBuf.String(), "fluent condition handler not initialized")
+
+	// Verify SetMessage
+	logBuf = bytes.Buffer{}
+	assert.Empty(t, logBuf.String())
+	fluentBuilder.SetMessage("some message")
+	assert.NotEqual(t, "some message", TestCondtion.ToK8sCondition().GetReason(&testObj))
+	assert.Contains(t, logBuf.String(), "fluent condition handler not initialized")
+
+	logBuf = bytes.Buffer{}
+	assert.Empty(t, logBuf.String())
+	fluentBuilder.SetMessageIfBlank("some message")
+	assert.NotEqual(t, "some message", TestCondtion.ToK8sCondition().GetReason(&testObj))
+	assert.Contains(t, logBuf.String(), "fluent condition handler not initialized")
+
+	// Verify Apply
+	logBuf = bytes.Buffer{}
+	assert.Empty(t, logBuf.String())
+	res := fluentBuilder.Apply(&testObj)
+	assert.False(t, res)
+	assert.Contains(t, logBuf.String(), "fluent condition handler not initialized")
+}

--- a/pkg/condition/fluent_test.go
+++ b/pkg/condition/fluent_test.go
@@ -14,10 +14,8 @@ import (
 func TestFluentConditionSetStatus(t *testing.T) {
 	testObj := newTestObjStd(TestCondtion)
 	assert.Equal(t, "True", TestCondtion.ToK8sCondition().GetStatus(&testObj))
-	assert.Equal(t, "True", TestCondtion.ToK8sCondition().GetStatus(&testObj.Status))
 	TestCondtion.ToFluentBuilder(&testObj).SetStatus("False").Apply(&testObj)
 	assert.Equal(t, "False", TestCondtion.ToK8sCondition().GetStatus(&testObj))
-	assert.Equal(t, "False", TestCondtion.ToK8sCondition().GetStatus(&testObj.Status))
 
 	assert.Equal(t, "", AnotherTestCondtion.GetStatus(&testObj))
 	assert.Equal(t, "", AnotherTestCondtion.GetStatus(&testObj.Status))
@@ -30,38 +28,28 @@ func TestFluentBoolHelpers(t *testing.T) {
 	testObj := newTestObjStd(TestCondtion)
 
 	assert.Equal(t, "True", TestCondtion.ToK8sCondition().GetStatus(&testObj))
-	assert.Equal(t, "True", TestCondtion.ToK8sCondition().GetStatus(&testObj.Status))
 	TestCondtion.ToFluentBuilder(&testObj).False().Apply(&testObj)
 	assert.Equal(t, "False", TestCondtion.ToK8sCondition().GetStatus(&testObj))
-	assert.Equal(t, "False", TestCondtion.ToK8sCondition().GetStatus(&testObj.Status))
 
 	assert.Equal(t, "", AnotherTestCondtion.ToK8sCondition().GetStatus(&testObj))
-	assert.Equal(t, "", AnotherTestCondtion.ToK8sCondition().GetStatus(&testObj.Status))
 	AnotherTestCondtion.ToFluentBuilder(&testObj).True().Apply(&testObj)
 	assert.Equal(t, "True", AnotherTestCondtion.ToK8sCondition().GetStatus(&testObj))
-	assert.Equal(t, "True", AnotherTestCondtion.ToK8sCondition().GetStatus(&testObj.Status))
 	AnotherTestCondtion.ToFluentBuilder(nil).Target(&testObj).False().Apply(&testObj)
 	assert.Equal(t, "False", AnotherTestCondtion.ToK8sCondition().GetStatus(&testObj))
-	assert.Equal(t, "False", AnotherTestCondtion.ToK8sCondition().GetStatus(&testObj.Status))
 
 	TestCondtion.ToFluentBuilder(&testObj).Unknown().Apply(&testObj)
 	assert.Equal(t, "Unknown", TestCondtion.ToK8sCondition().GetStatus(&testObj))
-	assert.Equal(t, "Unknown", TestCondtion.ToK8sCondition().GetStatus(&testObj.Status))
 }
 
 func TestFluentConditionSetStatusBool(t *testing.T) {
 	testObj := newTestObjStd(TestCondtion)
 	assert.Equal(t, "True", TestCondtion.ToK8sCondition().GetStatus(&testObj))
-	assert.Equal(t, "True", TestCondtion.ToK8sCondition().GetStatus(&testObj.Status))
 	TestCondtion.ToFluentBuilder(&testObj).SetStatusBool(false).Apply(&testObj)
 	assert.Equal(t, "False", TestCondtion.ToK8sCondition().GetStatus(&testObj))
-	assert.Equal(t, "False", TestCondtion.ToK8sCondition().GetStatus(&testObj.Status))
 
 	assert.Equal(t, "", AnotherTestCondtion.ToK8sCondition().GetStatus(&testObj))
-	assert.Equal(t, "", AnotherTestCondtion.ToK8sCondition().GetStatus(&testObj.Status))
 	AnotherTestCondtion.ToFluentBuilder(&testObj).SetStatusBool(true).Apply(&testObj)
 	assert.Equal(t, "True", AnotherTestCondtion.ToK8sCondition().GetStatus(&testObj))
-	assert.Equal(t, "True", AnotherTestCondtion.ToK8sCondition().GetStatus(&testObj.Status))
 }
 
 func TestSetError(t *testing.T) {

--- a/pkg/condition/fluent_test.go
+++ b/pkg/condition/fluent_test.go
@@ -13,96 +13,94 @@ import (
 
 func TestFluentConditionSetStatus(t *testing.T) {
 	testObj := newTestObjStd(TestCondtion)
-	assert.Equal(t, "True", TestCondtion.ToK8sCondition().GetStatus(&testObj))
-	TestCondtion.ToFluentBuilder(&testObj).SetStatus("False").Apply(&testObj)
-	assert.Equal(t, "False", TestCondtion.ToK8sCondition().GetStatus(&testObj))
+	assert.Equal(t, "True", TestCondtion.ToK8sCondition().GetStatus(testObj))
+	TestCondtion.ToFluentBuilder(testObj).SetStatus("False").Apply(testObj)
+	assert.Equal(t, "False", TestCondtion.ToK8sCondition().GetStatus(testObj))
 
-	assert.Equal(t, "", AnotherTestCondtion.GetStatus(&testObj))
-	assert.Equal(t, "", AnotherTestCondtion.GetStatus(&testObj.Status))
-	AnotherTestCondtion.ToFluentBuilder(&testObj).SetStatus("Unknown").Apply(&testObj)
-	assert.Equal(t, "Unknown", AnotherTestCondtion.GetStatus(&testObj))
-	assert.Equal(t, "Unknown", AnotherTestCondtion.GetStatus(&testObj.Status))
+	assert.Equal(t, "", AnotherTestCondtion.GetStatus(testObj))
+	AnotherTestCondtion.ToFluentBuilder(testObj).SetStatus("Unknown").Apply(testObj)
+	assert.Equal(t, "Unknown", AnotherTestCondtion.GetStatus(testObj))
 }
 
 func TestFluentBoolHelpers(t *testing.T) {
 	testObj := newTestObjStd(TestCondtion)
 
-	assert.Equal(t, "True", TestCondtion.ToK8sCondition().GetStatus(&testObj))
-	TestCondtion.ToFluentBuilder(&testObj).False().Apply(&testObj)
-	assert.Equal(t, "False", TestCondtion.ToK8sCondition().GetStatus(&testObj))
+	assert.Equal(t, "True", TestCondtion.ToK8sCondition().GetStatus(testObj))
+	TestCondtion.ToFluentBuilder(testObj).False().Apply(testObj)
+	assert.Equal(t, "False", TestCondtion.ToK8sCondition().GetStatus(testObj))
 
-	assert.Equal(t, "", AnotherTestCondtion.ToK8sCondition().GetStatus(&testObj))
-	AnotherTestCondtion.ToFluentBuilder(&testObj).True().Apply(&testObj)
-	assert.Equal(t, "True", AnotherTestCondtion.ToK8sCondition().GetStatus(&testObj))
-	AnotherTestCondtion.ToFluentBuilder(nil).Target(&testObj).False().Apply(&testObj)
-	assert.Equal(t, "False", AnotherTestCondtion.ToK8sCondition().GetStatus(&testObj))
+	assert.Equal(t, "", AnotherTestCondtion.ToK8sCondition().GetStatus(testObj))
+	AnotherTestCondtion.ToFluentBuilder(testObj).True().Apply(testObj)
+	assert.Equal(t, "True", AnotherTestCondtion.ToK8sCondition().GetStatus(testObj))
+	AnotherTestCondtion.ToFluentBuilder(nil).Target(testObj).False().Apply(testObj)
+	assert.Equal(t, "False", AnotherTestCondtion.ToK8sCondition().GetStatus(testObj))
 
-	TestCondtion.ToFluentBuilder(&testObj).Unknown().Apply(&testObj)
-	assert.Equal(t, "Unknown", TestCondtion.ToK8sCondition().GetStatus(&testObj))
+	TestCondtion.ToFluentBuilder(testObj).Unknown().Apply(testObj)
+	assert.Equal(t, "Unknown", TestCondtion.ToK8sCondition().GetStatus(testObj))
 }
 
 func TestFluentConditionSetStatusBool(t *testing.T) {
 	testObj := newTestObjStd(TestCondtion)
-	assert.Equal(t, "True", TestCondtion.ToK8sCondition().GetStatus(&testObj))
-	TestCondtion.ToFluentBuilder(&testObj).SetStatusBool(false).Apply(&testObj)
-	assert.Equal(t, "False", TestCondtion.ToK8sCondition().GetStatus(&testObj))
+	assert.Equal(t, "True", TestCondtion.ToK8sCondition().GetStatus(testObj))
+	TestCondtion.ToFluentBuilder(testObj).SetStatusBool(false).Apply(testObj)
+	assert.Equal(t, "False", TestCondtion.ToK8sCondition().GetStatus(testObj))
 
-	assert.Equal(t, "", AnotherTestCondtion.ToK8sCondition().GetStatus(&testObj))
-	AnotherTestCondtion.ToFluentBuilder(&testObj).SetStatusBool(true).Apply(&testObj)
-	assert.Equal(t, "True", AnotherTestCondtion.ToK8sCondition().GetStatus(&testObj))
+	assert.Equal(t, "", AnotherTestCondtion.ToK8sCondition().GetStatus(testObj))
+	AnotherTestCondtion.ToFluentBuilder(testObj).SetStatusBool(true).Apply(testObj)
+	assert.Equal(t, "True", AnotherTestCondtion.ToK8sCondition().GetStatus(testObj))
 }
 
 func TestSetError(t *testing.T) {
 	testObj := newTestObjStd(TestCondtion)
 	testErr := errors.New("test error")
 
-	TestCondtion.ToFluentBuilder(&testObj).SetError("it all broke", testErr).Apply(&testObj)
-	assert.Equal(t, "False", TestCondtion.ToK8sCondition().GetStatus(&testObj))
-	assert.Equal(t, "it all broke", TestCondtion.ToK8sCondition().GetReason(&testObj))
-	assert.Equal(t, "test error", TestCondtion.ToK8sCondition().GetMessage(&testObj))
+	TestCondtion.ToFluentBuilder(testObj).SetError("it all broke", testErr).Apply(testObj)
+	assert.Equal(t, "False", TestCondtion.ToK8sCondition().GetStatus(testObj))
+	assert.Equal(t, "it all broke", TestCondtion.ToK8sCondition().GetReason(testObj))
+	assert.Equal(t, "test error", TestCondtion.ToK8sCondition().GetMessage(testObj))
 
 	testErr = errors.New("another test error")
-	TestCondtion.ToFluentBuilder(&testObj).SetError("", testErr).Apply(&testObj)
-	assert.Equal(t, "False", TestCondtion.ToK8sCondition().GetStatus(&testObj))
-	assert.Equal(t, "Error", TestCondtion.ToK8sCondition().GetReason(&testObj))
-	assert.Equal(t, "another test error", TestCondtion.ToK8sCondition().GetMessage(&testObj))
+	TestCondtion.ToFluentBuilder(testObj).SetError("", testErr).Apply(testObj)
+	assert.Equal(t, "False", TestCondtion.ToK8sCondition().GetStatus(testObj))
+	assert.Equal(t, "Error", TestCondtion.ToK8sCondition().GetReason(testObj))
+	assert.Equal(t, "another test error", TestCondtion.ToK8sCondition().GetMessage(testObj))
 
-	TestCondtion.ToFluentBuilder(&testObj).SetError("Skip-itty Skip", generic.ErrSkip).Apply(&testObj)
-	assert.Equal(t, "True", TestCondtion.ToK8sCondition().GetStatus(&testObj))
-	assert.Equal(t, "Skip-itty Skip", TestCondtion.ToK8sCondition().GetReason(&testObj))
-	assert.Equal(t, "", TestCondtion.ToK8sCondition().GetMessage(&testObj))
+	TestCondtion.ToFluentBuilder(testObj).SetError("Skip-itty Skip", generic.ErrSkip).Apply(testObj)
+	assert.Equal(t, "True", TestCondtion.ToK8sCondition().GetStatus(testObj))
+	assert.Equal(t, "Skip-itty Skip", TestCondtion.ToK8sCondition().GetReason(testObj))
+	assert.Equal(t, "", TestCondtion.ToK8sCondition().GetMessage(testObj))
 }
 
 func TestFluentConditionSetReasonMethods(t *testing.T) {
 	testObj := newTestObjStd(TestCondtion)
-	TestCondtion.ToFluentBuilder(&testObj).SetReason("Because I Said So").Apply(&testObj)
-	assert.Equal(t, "Because I Said So", TestCondtion.ToK8sCondition().GetReason(&testObj))
+	TestCondtion.ToFluentBuilder(testObj).SetReason("Because I Said So").Apply(testObj)
+	assert.Equal(t, "Because I Said So", TestCondtion.ToK8sCondition().GetReason(testObj))
 
-	assert.Equal(t, "", AnotherTestCondtion.ToK8sCondition().GetReason(&testObj))
-	AnotherTestCondtion.ToFluentBuilder(&testObj).SetReason("Because Tom Said So").Apply(&testObj)
-	assert.Equal(t, "Because Tom Said So", AnotherTestCondtion.ToK8sCondition().GetReason(&testObj))
+	assert.Equal(t, "", AnotherTestCondtion.ToK8sCondition().GetReason(testObj))
+	AnotherTestCondtion.ToFluentBuilder(testObj).SetReason("Because Tom Said So").Apply(testObj)
+	assert.Equal(t, "Because Tom Said So", AnotherTestCondtion.ToK8sCondition().GetReason(testObj))
 }
 
 func TestFluentConditionSetMessage(t *testing.T) {
 	testObj := newTestObjStd(TestCondtion)
-	TestCondtion.ToFluentBuilder(&testObj).SetMessage("This will NOT be ignored").Apply(&testObj)
-	assert.Equal(t, "This will NOT be ignored", TestCondtion.GetMessage(&testObj))
+	TestCondtion.ToFluentBuilder(testObj).SetMessage("This will NOT be ignored").Apply(testObj)
+	assert.Equal(t, "This will NOT be ignored", TestCondtion.GetMessage(testObj))
 
-	assert.Equal(t, "", AnotherTestCondtion.GetMessage(&testObj))
-	AnotherTestCondtion.ToFluentBuilder(&testObj).SetMessage("This will be updated").Apply(&testObj)
-	assert.Equal(t, "This will be updated", AnotherTestCondtion.GetMessage(&testObj))
+	assert.Equal(t, "", AnotherTestCondtion.GetMessage(testObj))
+	AnotherTestCondtion.ToFluentBuilder(testObj).SetMessage("This will be updated").Apply(testObj)
+	assert.Equal(t, "This will be updated", AnotherTestCondtion.GetMessage(testObj))
 }
 
 func TestFluentConditionSetMessageIfBlank(t *testing.T) {
 	testObj := newTestObjStd(TestCondtion)
-	TestCondtion.ToFluentBuilder(&testObj).SetMessageIfBlank("This will be ignored").Apply(&testObj)
-	assert.NotEqual(t, "This will be ignored", TestCondtion.GetMessage(&testObj))
+	TestCondtion.ToFluentBuilder(testObj).SetMessageIfBlank("This will be ignored").Apply(testObj)
+	assert.NotEqual(t, "This will be ignored", TestCondtion.GetMessage(testObj))
 
-	assert.Equal(t, "", AnotherTestCondtion.GetMessage(&testObj))
-	AnotherTestCondtion.ToFluentBuilder(&testObj).SetMessageIfBlank("This will be updated").Apply(&testObj)
-	assert.Equal(t, "This will be updated", AnotherTestCondtion.GetMessage(&testObj))
-	AnotherTestCondtion.ToFluentBuilder(&testObj).SetMessageIfBlank("This will NOT be updated").Apply(&testObj)
-	assert.Equal(t, "This will be updated", AnotherTestCondtion.GetMessage(&testObj))
+	assert.Equal(t, "", AnotherTestCondtion.GetMessage(testObj))
+	AnotherTestCondtion.ToFluentBuilder(testObj).SetMessageIfBlank("This will be updated").Apply(testObj)
+	assert.Equal(t, "This will be updated", AnotherTestCondtion.GetMessage(testObj))
+	AnotherTestCondtion.ToFluentBuilder(testObj).SetMessageIfBlank("This will NOT be updated").Apply(testObj)
+	assert.Equal(t, "This will be updated", AnotherTestCondtion.GetMessage(testObj))
 }
 
 func TestIncorrectBuilder(t *testing.T) {
@@ -112,7 +110,7 @@ func TestIncorrectBuilder(t *testing.T) {
 	}
 
 	// Base control expectations
-	assert.Equal(t, "True", TestCondtion.ToK8sCondition().GetStatus(&testObj))
+	assert.Equal(t, "True", TestCondtion.ToK8sCondition().GetStatus(testObj))
 	assert.False(t, fluentBuilder.initedTarget)
 	assert.Equal(t, metav1.Condition{}, fluentBuilder.workingCondition)
 
@@ -123,7 +121,7 @@ func TestIncorrectBuilder(t *testing.T) {
 
 	// Verify SetStatus
 	fluentBuilder.SetStatus("Unknown")
-	assert.NotEqual(t, "Unknown", TestCondtion.ToK8sCondition().GetStatus(&testObj))
+	assert.NotEqual(t, "Unknown", TestCondtion.ToK8sCondition().GetStatus(testObj))
 	assert.Contains(t, logBuf.String(), "fluent condition handler not initialized")
 
 	// Verify SetError
@@ -137,26 +135,26 @@ func TestIncorrectBuilder(t *testing.T) {
 	logBuf = bytes.Buffer{}
 	assert.Empty(t, logBuf.String())
 	fluentBuilder.SetReason("for fun")
-	assert.NotEqual(t, "for fun", TestCondtion.ToK8sCondition().GetReason(&testObj))
+	assert.NotEqual(t, "for fun", TestCondtion.ToK8sCondition().GetReason(testObj))
 	assert.Contains(t, logBuf.String(), "fluent condition handler not initialized")
 
 	// Verify SetMessage
 	logBuf = bytes.Buffer{}
 	assert.Empty(t, logBuf.String())
 	fluentBuilder.SetMessage("some message")
-	assert.NotEqual(t, "some message", TestCondtion.ToK8sCondition().GetReason(&testObj))
+	assert.NotEqual(t, "some message", TestCondtion.ToK8sCondition().GetReason(testObj))
 	assert.Contains(t, logBuf.String(), "fluent condition handler not initialized")
 
 	logBuf = bytes.Buffer{}
 	assert.Empty(t, logBuf.String())
 	fluentBuilder.SetMessageIfBlank("some message")
-	assert.NotEqual(t, "some message", TestCondtion.ToK8sCondition().GetReason(&testObj))
+	assert.NotEqual(t, "some message", TestCondtion.ToK8sCondition().GetReason(testObj))
 	assert.Contains(t, logBuf.String(), "fluent condition handler not initialized")
 
 	// Verify Apply
 	logBuf = bytes.Buffer{}
 	assert.Empty(t, logBuf.String())
-	res := fluentBuilder.Apply(&testObj)
+	res := fluentBuilder.Apply(testObj)
 	assert.False(t, res)
 	assert.Contains(t, logBuf.String(), "fluent condition handler not initialized")
 }

--- a/pkg/condition/standardized.go
+++ b/pkg/condition/standardized.go
@@ -209,8 +209,11 @@ func (ch *MetaV1ConditionHandler) findOrCreateCondition(obj interface{}) *metav1
 	}
 
 	newCond := metav1.Condition{
-		Type:   ch.RootCondition.Name(),
-		Status: metav1.ConditionUnknown,
+		Type:               ch.RootCondition.Name(),
+		Status:             metav1.ConditionUnknown,
+		LastTransitionTime: metav1.NewTime(time.Now()),
+		Reason:             "Created",
+		Message:            "",
 	}
 
 	conditionsSlice, ok := getConditionSlice(obj)

--- a/pkg/condition/standardized.go
+++ b/pkg/condition/standardized.go
@@ -18,9 +18,6 @@ type MetaV1ConditionHandler struct {
 // and nil otherwise.
 func getConditionsSlice(obj interface{}) ([]metav1.Condition, bool) {
 	condSliceValue := getValue(obj, "Status", "Conditions")
-	if !condSliceValue.IsValid() {
-		condSliceValue = getValue(obj, "Conditions")
-	}
 
 	if !condSliceValue.IsValid() || condSliceValue.Kind() != reflect.Slice {
 		return nil, false
@@ -248,12 +245,18 @@ func (ch *MetaV1ConditionHandler) findOrCreateCondition(obj interface{}) *metav1
 }
 
 func setConditionsSlice(obj interface{}, conditions []metav1.Condition) {
+	statusValue := getValue(obj, "Status")
+	if !statusValue.IsValid() {
+		panic("object does not have a Status field")
+	}
+
 	condSliceValue := getValue(obj, "Status", "Conditions")
 	if !condSliceValue.IsValid() {
-		condSliceValue = getValue(obj, "Conditions")
-		if !condSliceValue.IsValid() {
-			panic("obj doesn't have conditions")
-		}
+		panic("Status does not have a Conditions field")
+	}
+
+	if condSliceValue.Kind() != reflect.Slice {
+		panic("Conditions field must be a slice")
 	}
 
 	condSliceValue.Set(reflect.ValueOf(conditions))

--- a/pkg/condition/standardized.go
+++ b/pkg/condition/standardized.go
@@ -1,0 +1,224 @@
+package condition
+
+import (
+	"errors"
+	"reflect"
+	"time"
+
+	"k8s.io/apimachinery/pkg/api/meta"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	"github.com/rancher/wrangler/v3/pkg/generic"
+)
+
+type MetaV1ConditionHandler struct {
+	RootCondition Cond
+}
+
+// getConditionSlice attempts to retrieve and validate the slice of conditions
+// from the given object. It returns the slice of metav1.Condition if successful,
+// and nil otherwise.
+func getConditionSlice(obj interface{}) ([]metav1.Condition, bool) {
+	condSliceValue := getValue(obj, "Status", "Conditions")
+	if !condSliceValue.IsValid() {
+		condSliceValue = getValue(obj, "Conditions")
+	}
+
+	if !condSliceValue.IsValid() || condSliceValue.Kind() != reflect.Slice {
+		return nil, false
+	}
+
+	condSliceInterface := condSliceValue.Interface()
+	conditions, ok := condSliceInterface.([]metav1.Condition)
+	return conditions, ok
+}
+
+func setConditionSlice(obj interface{}, conditions []metav1.Condition) {
+	condSliceValue := getValue(obj, "Status", "Conditions")
+	if !condSliceValue.IsValid() {
+		condSliceValue = getValue(obj, "Conditions")
+		if !condSliceValue.IsValid() {
+			panic("obj doesn't have conditions")
+		}
+	}
+
+	condSliceValue.Set(reflect.ValueOf(conditions))
+}
+
+func findCondition(obj interface{}, name string) *metav1.Condition {
+	conditionsSlice, ok := getConditionSlice(obj)
+	if !ok {
+		return nil
+	}
+	return meta.FindStatusCondition(conditionsSlice, name)
+}
+
+func (ch *MetaV1ConditionHandler) HasCondition(obj interface{}) bool {
+	foundCondition := findCondition(obj, ch.RootCondition.Name())
+	return foundCondition != nil
+}
+
+func (ch *MetaV1ConditionHandler) GetStatus(obj interface{}) string {
+	foundCondition := findCondition(obj, ch.RootCondition.Name())
+	if foundCondition == nil {
+		return ""
+	}
+
+	return string(foundCondition.Status)
+}
+
+func (ch *MetaV1ConditionHandler) SetStatus(obj interface{}, status string) {
+	ch.setStatus(obj, status)
+}
+
+func (ch *MetaV1ConditionHandler) SetStatusBool(obj interface{}, val bool) {
+	if val {
+		ch.setStatus(obj, "True")
+	} else {
+		ch.setStatus(obj, "False")
+	}
+}
+
+func (ch *MetaV1ConditionHandler) False(obj interface{}) {
+	ch.setStatus(obj, "False")
+}
+func (ch *MetaV1ConditionHandler) IsFalse(obj interface{}) bool {
+	foundCondition := findCondition(obj, ch.RootCondition.Name())
+	if foundCondition == nil {
+		return false
+	}
+
+	return foundCondition.Status == metav1.ConditionFalse
+}
+func (ch *MetaV1ConditionHandler) True(obj interface{}) {
+	ch.setStatus(obj, "True")
+}
+func (ch *MetaV1ConditionHandler) IsTrue(obj interface{}) bool {
+	foundCondition := findCondition(obj, ch.RootCondition.Name())
+	if foundCondition == nil {
+		return false
+	}
+
+	return foundCondition.Status == metav1.ConditionTrue
+}
+func (ch *MetaV1ConditionHandler) Unknown(obj interface{}) {
+	ch.setStatus(obj, "Unknown")
+}
+func (ch *MetaV1ConditionHandler) IsUnknown(obj interface{}) bool {
+	foundCondition := findCondition(obj, ch.RootCondition.Name())
+	if foundCondition == nil {
+		return false
+	}
+
+	return foundCondition.Status == metav1.ConditionUnknown
+}
+
+func (ch *MetaV1ConditionHandler) SetError(obj interface{}, reason string, err error) {
+	if err == nil || errors.Is(err, generic.ErrSkip) {
+		ch.True(obj)
+		ch.SetMessage(obj, "")
+		ch.SetReason(obj, reason)
+		return
+	}
+
+	if reason == "" {
+		reason = "Error"
+	}
+
+	ch.False(obj)
+	ch.SetMessage(obj, err.Error())
+	ch.SetReason(obj, reason)
+}
+func (ch *MetaV1ConditionHandler) MatchesError(obj interface{}, reason string, err error) bool {
+	if err == nil {
+		return ch.IsTrue(obj) &&
+			ch.GetMessage(obj) == "" &&
+			ch.GetReason(obj) == reason
+	}
+	if reason == "" {
+		reason = "Error"
+	}
+	return ch.IsFalse(obj) &&
+		ch.GetMessage(obj) == err.Error() &&
+		ch.GetReason(obj) == reason
+}
+
+func (ch *MetaV1ConditionHandler) GetReason(obj interface{}) string {
+	foundCondition := findCondition(obj, ch.RootCondition.Name())
+	if foundCondition == nil {
+		return ""
+	}
+
+	return foundCondition.Reason
+}
+
+func (ch *MetaV1ConditionHandler) SetReason(obj interface{}, reason string) {
+	cond := ch.findOrCreateCondition(obj)
+	cond.Reason = reason
+}
+
+func (ch *MetaV1ConditionHandler) GetMessage(obj interface{}) string {
+	foundCondition := findCondition(obj, ch.RootCondition.Name())
+	if foundCondition == nil {
+		return ""
+	}
+
+	return foundCondition.Message
+}
+
+func (ch *MetaV1ConditionHandler) SetMessage(obj interface{}, msg string) {
+	cond := ch.findOrCreateCondition(obj)
+	cond.Message = msg
+}
+
+func (ch *MetaV1ConditionHandler) SetMessageIfBlank(obj interface{}, msg string) {
+	cond := ch.findOrCreateCondition(obj)
+	if cond.Message == "" {
+		cond.Message = msg
+	}
+}
+
+func (ch *MetaV1ConditionHandler) touchTransitionTS(condition *metav1.Condition) {
+	now := metav1.NewTime(time.Now())
+	condition.LastTransitionTime = now
+}
+
+func (ch *MetaV1ConditionHandler) setStatus(obj interface{}, status string) {
+	if reflect.TypeOf(obj).Kind() != reflect.Ptr {
+		panic("obj passed must be a pointer")
+	}
+
+	if status != string(metav1.ConditionTrue) &&
+		status != string(metav1.ConditionFalse) &&
+		status != string(metav1.ConditionUnknown) {
+		panic("unknown condition status: " + status)
+	}
+
+	statusParsed := metav1.ConditionStatus(status)
+	cond := ch.findOrCreateCondition(obj)
+	if cond.Status != statusParsed {
+		ch.touchTransitionTS(cond)
+	}
+	cond.Status = statusParsed
+}
+
+func (ch *MetaV1ConditionHandler) findOrCreateCondition(obj interface{}) *metav1.Condition {
+	foundCondition := findCondition(obj, ch.RootCondition.Name())
+	if foundCondition != nil {
+		return foundCondition
+	}
+
+	newCond := metav1.Condition{
+		Type:   ch.RootCondition.Name(),
+		Status: metav1.ConditionUnknown,
+	}
+
+	conditionsSlice, ok := getConditionSlice(obj)
+	if !ok {
+		panic("conditions slice does not exist")
+	}
+
+	conditionsSlice = append(conditionsSlice, newCond)
+	setConditionSlice(obj, conditionsSlice)
+	return findCondition(obj, ch.RootCondition.Name())
+}

--- a/pkg/condition/standardized_test.go
+++ b/pkg/condition/standardized_test.go
@@ -54,67 +54,50 @@ func TestConditionToKatesCondition(t *testing.T) {
 func TestStandardConditionHasCondition(t *testing.T) {
 	testObj := newTestObjStd(TestCondtion)
 	assert.Equal(t, true, TestCondtion.ToK8sCondition().HasCondition(&testObj))
-	assert.Equal(t, true, TestCondtion.ToK8sCondition().HasCondition(&testObj.Status))
 
 	assert.Equal(t, false, AnotherTestCondtion.ToK8sCondition().HasCondition(&testObj))
-	assert.Equal(t, false, AnotherTestCondtion.ToK8sCondition().HasCondition(&testObj.Status))
 }
 
 func TestStandardConditionGetStatus(t *testing.T) {
 	testObj := newTestObjStd(TestCondtion)
 	assert.Equal(t, "True", TestCondtion.ToK8sCondition().GetStatus(&testObj))
-	assert.Equal(t, "True", TestCondtion.ToK8sCondition().GetStatus(&testObj.Status))
 
 	assert.Equal(t, "", AnotherTestCondtion.ToK8sCondition().GetStatus(&testObj))
-	assert.Equal(t, "", AnotherTestCondtion.ToK8sCondition().GetStatus(&testObj.Status))
 }
 
 func TestStandardConditionSetStatus(t *testing.T) {
 	testObj := newTestObjStd(TestCondtion)
 	assert.Equal(t, "True", TestCondtion.ToK8sCondition().GetStatus(&testObj))
-	assert.Equal(t, "True", TestCondtion.ToK8sCondition().GetStatus(&testObj.Status))
 	TestCondtion.ToK8sCondition().SetStatus(&testObj, "False")
 	assert.Equal(t, "False", TestCondtion.ToK8sCondition().GetStatus(&testObj))
-	assert.Equal(t, "False", TestCondtion.ToK8sCondition().GetStatus(&testObj.Status))
 
 	assert.Equal(t, "", AnotherTestCondtion.GetStatus(&testObj))
-	assert.Equal(t, "", AnotherTestCondtion.GetStatus(&testObj.Status))
 	AnotherTestCondtion.SetStatus(&testObj, "Unknown")
 	assert.Equal(t, "Unknown", AnotherTestCondtion.GetStatus(&testObj))
-	assert.Equal(t, "Unknown", AnotherTestCondtion.GetStatus(&testObj.Status))
 }
 
 func TestStandardBoolHelpers(t *testing.T) {
 	testObj := newTestObjStd(TestCondtion)
 	assert.Equal(t, "True", TestCondtion.ToK8sCondition().GetStatus(&testObj))
-	assert.Equal(t, "True", TestCondtion.ToK8sCondition().GetStatus(&testObj.Status))
 	TestCondtion.ToK8sCondition().False(&testObj)
 	assert.Equal(t, "False", TestCondtion.ToK8sCondition().GetStatus(&testObj))
-	assert.Equal(t, "False", TestCondtion.ToK8sCondition().GetStatus(&testObj.Status))
 
 	assert.Equal(t, "", AnotherTestCondtion.ToK8sCondition().GetStatus(&testObj))
-	assert.Equal(t, "", AnotherTestCondtion.ToK8sCondition().GetStatus(&testObj.Status))
 	AnotherTestCondtion.ToK8sCondition().True(&testObj)
 	assert.Equal(t, "True", AnotherTestCondtion.ToK8sCondition().GetStatus(&testObj))
-	assert.Equal(t, "True", AnotherTestCondtion.ToK8sCondition().GetStatus(&testObj.Status))
 	AnotherTestCondtion.ToK8sCondition().False(&testObj)
 	assert.Equal(t, "False", AnotherTestCondtion.ToK8sCondition().GetStatus(&testObj))
-	assert.Equal(t, "False", AnotherTestCondtion.ToK8sCondition().GetStatus(&testObj.Status))
 }
 
 func TestStandardConditionSetStatusBool(t *testing.T) {
 	testObj := newTestObjStd(TestCondtion)
 	assert.Equal(t, "True", TestCondtion.ToK8sCondition().GetStatus(&testObj))
-	assert.Equal(t, "True", TestCondtion.ToK8sCondition().GetStatus(&testObj.Status))
 	TestCondtion.ToK8sCondition().SetStatusBool(&testObj, false)
 	assert.Equal(t, "False", TestCondtion.ToK8sCondition().GetStatus(&testObj))
-	assert.Equal(t, "False", TestCondtion.ToK8sCondition().GetStatus(&testObj.Status))
 
 	assert.Equal(t, "", AnotherTestCondtion.ToK8sCondition().GetStatus(&testObj))
-	assert.Equal(t, "", AnotherTestCondtion.ToK8sCondition().GetStatus(&testObj.Status))
 	AnotherTestCondtion.ToK8sCondition().SetStatusBool(&testObj, true)
 	assert.Equal(t, "True", AnotherTestCondtion.ToK8sCondition().GetStatus(&testObj))
-	assert.Equal(t, "True", AnotherTestCondtion.ToK8sCondition().GetStatus(&testObj.Status))
 }
 
 func TestStandardConditionSetReasonMethods(t *testing.T) {

--- a/pkg/condition/standardized_test.go
+++ b/pkg/condition/standardized_test.go
@@ -117,7 +117,7 @@ func TestStandardConditionSetStatusBool(t *testing.T) {
 	assert.Equal(t, "True", AnotherTestCondtion.ToK8sCondition().GetStatus(&testObj.Status))
 }
 
-func TestStandardConditionReasonMethods(t *testing.T) {
+func TestStandardConditionSetReasonMethods(t *testing.T) {
 	testObj := newTestObjStd(TestCondtion)
 	TestCondtion.ToK8sCondition().SetReason(&testObj, "Because I Said So")
 	assert.Equal(t, "Because I Said So", TestCondtion.ToK8sCondition().GetReason(&testObj))

--- a/pkg/condition/standardized_test.go
+++ b/pkg/condition/standardized_test.go
@@ -4,6 +4,8 @@ import (
 	"errors"
 	"github.com/stretchr/testify/assert"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
 	"testing"
 )
 
@@ -12,7 +14,14 @@ type testObjStatusStd struct {
 }
 
 type testResourceObjStd struct {
-	Status testObjStatusStd `json:"status"`
+	metav1.TypeMeta   `json:",inline"`
+	metav1.ObjectMeta `json:"metadata,omitempty"`
+	Status            testObjStatusStd `json:"status"`
+}
+
+func (t testResourceObjStd) DeepCopyObject() runtime.Object {
+	//TODO implement me
+	panic("implement me")
 }
 
 func newKatesCondition(condition Cond, message string) metav1.Condition {
@@ -23,7 +32,7 @@ func newKatesCondition(condition Cond, message string) metav1.Condition {
 	}
 }
 
-func newTestObjStd(conditions ...Cond) testResourceObjStd {
+func newTestObjStd(conditions ...Cond) client.Object {
 	newObj := testResourceObjStd{
 		Status: testObjStatusStd{
 			Conditions: []metav1.Condition{},
@@ -40,7 +49,7 @@ func newTestObjStd(conditions ...Cond) testResourceObjStd {
 	}
 	newObj.Status.Conditions = newConditions
 
-	return newObj
+	return &newObj
 }
 
 func TestConditionToKatesCondition(t *testing.T) {
@@ -53,83 +62,83 @@ func TestConditionToKatesCondition(t *testing.T) {
 
 func TestStandardConditionHasCondition(t *testing.T) {
 	testObj := newTestObjStd(TestCondtion)
-	assert.Equal(t, true, TestCondtion.ToK8sCondition().HasCondition(&testObj))
+	assert.Equal(t, true, TestCondtion.ToK8sCondition().HasCondition(testObj))
 
-	assert.Equal(t, false, AnotherTestCondtion.ToK8sCondition().HasCondition(&testObj))
+	assert.Equal(t, false, AnotherTestCondtion.ToK8sCondition().HasCondition(testObj))
 }
 
 func TestStandardConditionGetStatus(t *testing.T) {
 	testObj := newTestObjStd(TestCondtion)
-	assert.Equal(t, "True", TestCondtion.ToK8sCondition().GetStatus(&testObj))
+	assert.Equal(t, "True", TestCondtion.ToK8sCondition().GetStatus(testObj))
 
-	assert.Equal(t, "", AnotherTestCondtion.ToK8sCondition().GetStatus(&testObj))
+	assert.Equal(t, "", AnotherTestCondtion.ToK8sCondition().GetStatus(testObj))
 }
 
 func TestStandardConditionSetStatus(t *testing.T) {
 	testObj := newTestObjStd(TestCondtion)
-	assert.Equal(t, "True", TestCondtion.ToK8sCondition().GetStatus(&testObj))
-	TestCondtion.ToK8sCondition().SetStatus(&testObj, "False")
-	assert.Equal(t, "False", TestCondtion.ToK8sCondition().GetStatus(&testObj))
+	assert.Equal(t, "True", TestCondtion.ToK8sCondition().GetStatus(testObj))
+	TestCondtion.ToK8sCondition().SetStatus(testObj, "False")
+	assert.Equal(t, "False", TestCondtion.ToK8sCondition().GetStatus(testObj))
 
-	assert.Equal(t, "", AnotherTestCondtion.GetStatus(&testObj))
-	AnotherTestCondtion.SetStatus(&testObj, "Unknown")
-	assert.Equal(t, "Unknown", AnotherTestCondtion.GetStatus(&testObj))
+	assert.Equal(t, "", AnotherTestCondtion.GetStatus(testObj))
+	AnotherTestCondtion.SetStatus(testObj, "Unknown")
+	assert.Equal(t, "Unknown", AnotherTestCondtion.GetStatus(testObj))
 }
 
 func TestStandardBoolHelpers(t *testing.T) {
 	testObj := newTestObjStd(TestCondtion)
-	assert.Equal(t, "True", TestCondtion.ToK8sCondition().GetStatus(&testObj))
-	TestCondtion.ToK8sCondition().False(&testObj)
-	assert.Equal(t, "False", TestCondtion.ToK8sCondition().GetStatus(&testObj))
+	assert.Equal(t, "True", TestCondtion.ToK8sCondition().GetStatus(testObj))
+	TestCondtion.ToK8sCondition().False(testObj)
+	assert.Equal(t, "False", TestCondtion.ToK8sCondition().GetStatus(testObj))
 
-	assert.Equal(t, "", AnotherTestCondtion.ToK8sCondition().GetStatus(&testObj))
-	AnotherTestCondtion.ToK8sCondition().True(&testObj)
-	assert.Equal(t, "True", AnotherTestCondtion.ToK8sCondition().GetStatus(&testObj))
-	AnotherTestCondtion.ToK8sCondition().False(&testObj)
-	assert.Equal(t, "False", AnotherTestCondtion.ToK8sCondition().GetStatus(&testObj))
+	assert.Equal(t, "", AnotherTestCondtion.ToK8sCondition().GetStatus(testObj))
+	AnotherTestCondtion.ToK8sCondition().True(testObj)
+	assert.Equal(t, "True", AnotherTestCondtion.ToK8sCondition().GetStatus(testObj))
+	AnotherTestCondtion.ToK8sCondition().False(testObj)
+	assert.Equal(t, "False", AnotherTestCondtion.ToK8sCondition().GetStatus(testObj))
 }
 
 func TestStandardConditionSetStatusBool(t *testing.T) {
 	testObj := newTestObjStd(TestCondtion)
-	assert.Equal(t, "True", TestCondtion.ToK8sCondition().GetStatus(&testObj))
-	TestCondtion.ToK8sCondition().SetStatusBool(&testObj, false)
-	assert.Equal(t, "False", TestCondtion.ToK8sCondition().GetStatus(&testObj))
+	assert.Equal(t, "True", TestCondtion.ToK8sCondition().GetStatus(testObj))
+	TestCondtion.ToK8sCondition().SetStatusBool(testObj, false)
+	assert.Equal(t, "False", TestCondtion.ToK8sCondition().GetStatus(testObj))
 
-	assert.Equal(t, "", AnotherTestCondtion.ToK8sCondition().GetStatus(&testObj))
-	AnotherTestCondtion.ToK8sCondition().SetStatusBool(&testObj, true)
-	assert.Equal(t, "True", AnotherTestCondtion.ToK8sCondition().GetStatus(&testObj))
+	assert.Equal(t, "", AnotherTestCondtion.ToK8sCondition().GetStatus(testObj))
+	AnotherTestCondtion.ToK8sCondition().SetStatusBool(testObj, true)
+	assert.Equal(t, "True", AnotherTestCondtion.ToK8sCondition().GetStatus(testObj))
 }
 
 func TestStandardConditionSetReasonMethods(t *testing.T) {
 	testObj := newTestObjStd(TestCondtion)
-	TestCondtion.ToK8sCondition().SetReason(&testObj, "Because I Said So")
-	assert.Equal(t, "Because I Said So", TestCondtion.ToK8sCondition().GetReason(&testObj))
+	TestCondtion.ToK8sCondition().SetReason(testObj, "Because I Said So")
+	assert.Equal(t, "Because I Said So", TestCondtion.ToK8sCondition().GetReason(testObj))
 
-	assert.Equal(t, "", AnotherTestCondtion.ToK8sCondition().GetReason(&testObj))
-	AnotherTestCondtion.ToK8sCondition().SetReason(&testObj, "Because Tom Said So")
-	assert.Equal(t, "Because Tom Said So", AnotherTestCondtion.ToK8sCondition().GetReason(&testObj))
+	assert.Equal(t, "", AnotherTestCondtion.ToK8sCondition().GetReason(testObj))
+	AnotherTestCondtion.ToK8sCondition().SetReason(testObj, "Because Tom Said So")
+	assert.Equal(t, "Because Tom Said So", AnotherTestCondtion.ToK8sCondition().GetReason(testObj))
 }
 
 func TestStandardConditionSetMessageIfBlank(t *testing.T) {
 	testObj := newTestObjStd(TestCondtion)
-	TestCondtion.ToK8sCondition().SetMessageIfBlank(&testObj, "This will be ignored")
-	assert.NotEqual(t, "This will be ignored", TestCondtion.GetMessage(&testObj))
+	TestCondtion.ToK8sCondition().SetMessageIfBlank(testObj, "This will be ignored")
+	assert.NotEqual(t, "This will be ignored", TestCondtion.GetMessage(testObj))
 
-	assert.Equal(t, "", AnotherTestCondtion.GetMessage(&testObj))
-	AnotherTestCondtion.ToK8sCondition().SetMessageIfBlank(&testObj, "This will be updated")
-	assert.Equal(t, "This will be updated", AnotherTestCondtion.GetMessage(&testObj))
-	AnotherTestCondtion.ToK8sCondition().SetMessageIfBlank(&testObj, "This will NOT be updated")
-	assert.Equal(t, "This will be updated", AnotherTestCondtion.GetMessage(&testObj))
+	assert.Equal(t, "", AnotherTestCondtion.GetMessage(testObj))
+	AnotherTestCondtion.ToK8sCondition().SetMessageIfBlank(testObj, "This will be updated")
+	assert.Equal(t, "This will be updated", AnotherTestCondtion.GetMessage(testObj))
+	AnotherTestCondtion.ToK8sCondition().SetMessageIfBlank(testObj, "This will NOT be updated")
+	assert.Equal(t, "This will be updated", AnotherTestCondtion.GetMessage(testObj))
 }
 
 func TestStandardConditionMessageMethods(t *testing.T) {
 	testObj := newTestObjStd(TestCondtion)
-	assert.Equal(t, "Hello World", TestCondtion.ToK8sCondition().GetMessage(&testObj))
-	TestCondtion.ToK8sCondition().SetMessage(&testObj, "")
-	assert.Equal(t, "", TestCondtion.ToK8sCondition().GetMessage(&testObj))
+	assert.Equal(t, "Hello World", TestCondtion.ToK8sCondition().GetMessage(testObj))
+	TestCondtion.ToK8sCondition().SetMessage(testObj, "")
+	assert.Equal(t, "", TestCondtion.ToK8sCondition().GetMessage(testObj))
 
-	AnotherTestCondtion.ToK8sCondition().SetMessage(&testObj, "This will be updated")
-	assert.Equal(t, "This will be updated", AnotherTestCondtion.ToK8sCondition().GetMessage(&testObj))
+	AnotherTestCondtion.ToK8sCondition().SetMessage(testObj, "This will be updated")
+	assert.Equal(t, "This will be updated", AnotherTestCondtion.ToK8sCondition().GetMessage(testObj))
 }
 
 func TestStandardConditionErrorMethods(t *testing.T) {
@@ -138,22 +147,22 @@ func TestStandardConditionErrorMethods(t *testing.T) {
 	testError := errors.New("some test error")
 
 	testObj := newTestObjStd(TestCondtion)
-	TestCondtion.ToK8sCondition().False(&testObj)
-	SubStatusCondition.ToK8sCondition().False(&testObj)
-	SubStatusCondition.ToK8sCondition().SetError(&testObj, "", testError)
+	TestCondtion.ToK8sCondition().False(testObj)
+	SubStatusCondition.ToK8sCondition().False(testObj)
+	SubStatusCondition.ToK8sCondition().SetError(testObj, "", testError)
 
-	assert.Equal(t, "Error", SubStatusCondition.ToK8sCondition().GetReason(&testObj))
-	assert.Equal(t, "some test error", SubStatusCondition.ToK8sCondition().GetMessage(&testObj))
-	assert.True(t, SubStatusCondition.ToK8sCondition().MatchesError(&testObj, "Error", testError))
-	assert.True(t, SubStatusCondition.ToK8sCondition().MatchesError(&testObj, "", testError))
+	assert.Equal(t, "Error", SubStatusCondition.ToK8sCondition().GetReason(testObj))
+	assert.Equal(t, "some test error", SubStatusCondition.ToK8sCondition().GetMessage(testObj))
+	assert.True(t, SubStatusCondition.ToK8sCondition().MatchesError(testObj, "Error", testError))
+	assert.True(t, SubStatusCondition.ToK8sCondition().MatchesError(testObj, "", testError))
 
-	SubStatusCondition.ToK8sCondition().SetError(&testObj, "Because it Broke", testError)
-	assert.False(t, SubStatusCondition.ToK8sCondition().MatchesError(&testObj, "", testError))
-	assert.True(t, SubStatusCondition.ToK8sCondition().MatchesError(&testObj, "Because it Broke", testError))
-	assert.False(t, SubStatusCondition.ToK8sCondition().MatchesError(&testObj, "Because something else Broke", testError))
+	SubStatusCondition.ToK8sCondition().SetError(testObj, "Because it Broke", testError)
+	assert.False(t, SubStatusCondition.ToK8sCondition().MatchesError(testObj, "", testError))
+	assert.True(t, SubStatusCondition.ToK8sCondition().MatchesError(testObj, "Because it Broke", testError))
+	assert.False(t, SubStatusCondition.ToK8sCondition().MatchesError(testObj, "Because something else Broke", testError))
 
-	SubStatusCondition.ToK8sCondition().SetError(&testObj, "Because something else Broke", nil)
-	assert.False(t, SubStatusCondition.ToK8sCondition().MatchesError(&testObj, "Because something else Broke", testError))
-	assert.True(t, SubStatusCondition.ToK8sCondition().MatchesError(&testObj, "Because something else Broke", nil))
+	SubStatusCondition.ToK8sCondition().SetError(testObj, "Because something else Broke", nil)
+	assert.False(t, SubStatusCondition.ToK8sCondition().MatchesError(testObj, "Because something else Broke", testError))
+	assert.True(t, SubStatusCondition.ToK8sCondition().MatchesError(testObj, "Because something else Broke", nil))
 
 }

--- a/pkg/condition/standardized_test.go
+++ b/pkg/condition/standardized_test.go
@@ -1,0 +1,176 @@
+package condition
+
+import (
+	"errors"
+	"github.com/stretchr/testify/assert"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"testing"
+)
+
+type testObjStatusStd struct {
+	Conditions []metav1.Condition `json:"conditions"`
+}
+
+type testResourceObjStd struct {
+	Status testObjStatusStd `json:"status"`
+}
+
+func newKatesCondition(condition Cond, message string) metav1.Condition {
+	return metav1.Condition{
+		Type:    string(condition),
+		Status:  metav1.ConditionTrue,
+		Message: message,
+	}
+}
+
+func newTestObjStd(conditions ...Cond) testResourceObjStd {
+	newObj := testResourceObjStd{
+		Status: testObjStatusStd{
+			Conditions: []metav1.Condition{},
+		},
+	}
+	newConditions := make([]metav1.Condition, 0, len(conditions))
+	if len(conditions) > 0 {
+		for _, condition := range conditions {
+			newConditions = append(
+				newConditions,
+				newKatesCondition(condition, "Hello World"),
+			)
+		}
+	}
+	newObj.Status.Conditions = newConditions
+
+	return newObj
+}
+
+func TestConditionToKatesCondition(t *testing.T) {
+	katesCondition := TestCondtion.ToKatesCondition()
+	expected := MetaV1ConditionHandler{
+		RootCondition: TestCondtion,
+	}
+	assert.Equal(t, &expected, katesCondition)
+}
+
+func TestStandardConditionHasCondition(t *testing.T) {
+	testObj := newTestObjStd(TestCondtion)
+	assert.Equal(t, true, TestCondtion.ToKatesCondition().HasCondition(&testObj))
+	assert.Equal(t, true, TestCondtion.ToKatesCondition().HasCondition(&testObj.Status))
+
+	assert.Equal(t, false, AnotherTestCondtion.ToKatesCondition().HasCondition(&testObj))
+	assert.Equal(t, false, AnotherTestCondtion.ToKatesCondition().HasCondition(&testObj.Status))
+}
+
+func TestStandardConditionGetStatus(t *testing.T) {
+	testObj := newTestObjStd(TestCondtion)
+	assert.Equal(t, "True", TestCondtion.ToKatesCondition().GetStatus(&testObj))
+	assert.Equal(t, "True", TestCondtion.ToKatesCondition().GetStatus(&testObj.Status))
+
+	assert.Equal(t, "", AnotherTestCondtion.ToKatesCondition().GetStatus(&testObj))
+	assert.Equal(t, "", AnotherTestCondtion.ToKatesCondition().GetStatus(&testObj.Status))
+}
+
+func TestStandardConditionSetStatus(t *testing.T) {
+	testObj := newTestObjStd(TestCondtion)
+	assert.Equal(t, "True", TestCondtion.ToKatesCondition().GetStatus(&testObj))
+	assert.Equal(t, "True", TestCondtion.ToKatesCondition().GetStatus(&testObj.Status))
+	TestCondtion.ToKatesCondition().SetStatus(&testObj, "False")
+	assert.Equal(t, "False", TestCondtion.ToKatesCondition().GetStatus(&testObj))
+	assert.Equal(t, "False", TestCondtion.ToKatesCondition().GetStatus(&testObj.Status))
+
+	assert.Equal(t, "", AnotherTestCondtion.GetStatus(&testObj))
+	assert.Equal(t, "", AnotherTestCondtion.GetStatus(&testObj.Status))
+	AnotherTestCondtion.SetStatus(&testObj, "Unknown")
+	assert.Equal(t, "Unknown", AnotherTestCondtion.GetStatus(&testObj))
+	assert.Equal(t, "Unknown", AnotherTestCondtion.GetStatus(&testObj.Status))
+}
+
+func TestStandardBoolHelpers(t *testing.T) {
+	testObj := newTestObjStd(TestCondtion)
+	assert.Equal(t, "True", TestCondtion.ToKatesCondition().GetStatus(&testObj))
+	assert.Equal(t, "True", TestCondtion.ToKatesCondition().GetStatus(&testObj.Status))
+	TestCondtion.ToKatesCondition().False(&testObj)
+	assert.Equal(t, "False", TestCondtion.ToKatesCondition().GetStatus(&testObj))
+	assert.Equal(t, "False", TestCondtion.ToKatesCondition().GetStatus(&testObj.Status))
+
+	assert.Equal(t, "", AnotherTestCondtion.ToKatesCondition().GetStatus(&testObj))
+	assert.Equal(t, "", AnotherTestCondtion.ToKatesCondition().GetStatus(&testObj.Status))
+	AnotherTestCondtion.ToKatesCondition().True(&testObj)
+	assert.Equal(t, "True", AnotherTestCondtion.ToKatesCondition().GetStatus(&testObj))
+	assert.Equal(t, "True", AnotherTestCondtion.ToKatesCondition().GetStatus(&testObj.Status))
+	AnotherTestCondtion.ToKatesCondition().False(&testObj)
+	assert.Equal(t, "False", AnotherTestCondtion.ToKatesCondition().GetStatus(&testObj))
+	assert.Equal(t, "False", AnotherTestCondtion.ToKatesCondition().GetStatus(&testObj.Status))
+}
+
+func TestStandardConditionSetStatusBool(t *testing.T) {
+	testObj := newTestObjStd(TestCondtion)
+	assert.Equal(t, "True", TestCondtion.ToKatesCondition().GetStatus(&testObj))
+	assert.Equal(t, "True", TestCondtion.ToKatesCondition().GetStatus(&testObj.Status))
+	TestCondtion.ToKatesCondition().SetStatusBool(&testObj, false)
+	assert.Equal(t, "False", TestCondtion.ToKatesCondition().GetStatus(&testObj))
+	assert.Equal(t, "False", TestCondtion.ToKatesCondition().GetStatus(&testObj.Status))
+
+	assert.Equal(t, "", AnotherTestCondtion.ToKatesCondition().GetStatus(&testObj))
+	assert.Equal(t, "", AnotherTestCondtion.ToKatesCondition().GetStatus(&testObj.Status))
+	AnotherTestCondtion.ToKatesCondition().SetStatusBool(&testObj, true)
+	assert.Equal(t, "True", AnotherTestCondtion.ToKatesCondition().GetStatus(&testObj))
+	assert.Equal(t, "True", AnotherTestCondtion.ToKatesCondition().GetStatus(&testObj.Status))
+}
+
+func TestStandardConditionReasonMethods(t *testing.T) {
+	testObj := newTestObjStd(TestCondtion)
+	TestCondtion.ToKatesCondition().SetReason(&testObj, "Because I Said So")
+	assert.Equal(t, "Because I Said So", TestCondtion.ToKatesCondition().GetReason(&testObj))
+
+	assert.Equal(t, "", AnotherTestCondtion.ToKatesCondition().GetReason(&testObj))
+	AnotherTestCondtion.ToKatesCondition().SetReason(&testObj, "Because Tom Said So")
+	assert.Equal(t, "Because Tom Said So", AnotherTestCondtion.ToKatesCondition().GetReason(&testObj))
+}
+
+func TestStandardConditionSetMessageIfBlank(t *testing.T) {
+	testObj := newTestObjStd(TestCondtion)
+	TestCondtion.ToKatesCondition().SetMessageIfBlank(&testObj, "This will be ignored")
+	assert.NotEqual(t, "This will be ignored", TestCondtion.GetMessage(&testObj))
+
+	assert.Equal(t, "", AnotherTestCondtion.GetMessage(&testObj))
+	AnotherTestCondtion.ToKatesCondition().SetMessageIfBlank(&testObj, "This will be updated")
+	assert.Equal(t, "This will be updated", AnotherTestCondtion.GetMessage(&testObj))
+	AnotherTestCondtion.ToKatesCondition().SetMessageIfBlank(&testObj, "This will NOT be updated")
+	assert.Equal(t, "This will be updated", AnotherTestCondtion.GetMessage(&testObj))
+}
+
+func TestStandardConditionMessageMethods(t *testing.T) {
+	testObj := newTestObjStd(TestCondtion)
+	assert.Equal(t, "Hello World", TestCondtion.ToKatesCondition().GetMessage(&testObj))
+	TestCondtion.ToKatesCondition().SetMessage(&testObj, "")
+	assert.Equal(t, "", TestCondtion.ToKatesCondition().GetMessage(&testObj))
+
+	AnotherTestCondtion.ToKatesCondition().SetMessage(&testObj, "This will be updated")
+	assert.Equal(t, "This will be updated", AnotherTestCondtion.ToKatesCondition().GetMessage(&testObj))
+}
+
+func TestStandardConditionErrorMethods(t *testing.T) {
+	const SubStatusCondition Cond = "SomeStepSpecificState"
+
+	testError := errors.New("some test error")
+
+	testObj := newTestObjStd(TestCondtion)
+	TestCondtion.ToKatesCondition().False(&testObj)
+	SubStatusCondition.ToKatesCondition().False(&testObj)
+	SubStatusCondition.ToKatesCondition().SetError(&testObj, "", testError)
+
+	assert.Equal(t, "Error", SubStatusCondition.ToKatesCondition().GetReason(&testObj))
+	assert.Equal(t, "some test error", SubStatusCondition.ToKatesCondition().GetMessage(&testObj))
+	assert.True(t, SubStatusCondition.ToKatesCondition().MatchesError(&testObj, "Error", testError))
+	assert.True(t, SubStatusCondition.ToKatesCondition().MatchesError(&testObj, "", testError))
+
+	SubStatusCondition.ToKatesCondition().SetError(&testObj, "Because it Broke", testError)
+	assert.False(t, SubStatusCondition.ToKatesCondition().MatchesError(&testObj, "", testError))
+	assert.True(t, SubStatusCondition.ToKatesCondition().MatchesError(&testObj, "Because it Broke", testError))
+	assert.False(t, SubStatusCondition.ToKatesCondition().MatchesError(&testObj, "Because something else Broke", testError))
+
+	SubStatusCondition.ToKatesCondition().SetError(&testObj, "Because something else Broke", nil)
+	assert.False(t, SubStatusCondition.ToKatesCondition().MatchesError(&testObj, "Because something else Broke", testError))
+	assert.True(t, SubStatusCondition.ToKatesCondition().MatchesError(&testObj, "Because something else Broke", nil))
+
+}

--- a/pkg/condition/standardized_test.go
+++ b/pkg/condition/standardized_test.go
@@ -44,7 +44,7 @@ func newTestObjStd(conditions ...Cond) testResourceObjStd {
 }
 
 func TestConditionToKatesCondition(t *testing.T) {
-	katesCondition := TestCondtion.ToKatesCondition()
+	katesCondition := TestCondtion.ToK8sCondition()
 	expected := MetaV1ConditionHandler{
 		RootCondition: TestCondtion,
 	}
@@ -53,29 +53,29 @@ func TestConditionToKatesCondition(t *testing.T) {
 
 func TestStandardConditionHasCondition(t *testing.T) {
 	testObj := newTestObjStd(TestCondtion)
-	assert.Equal(t, true, TestCondtion.ToKatesCondition().HasCondition(&testObj))
-	assert.Equal(t, true, TestCondtion.ToKatesCondition().HasCondition(&testObj.Status))
+	assert.Equal(t, true, TestCondtion.ToK8sCondition().HasCondition(&testObj))
+	assert.Equal(t, true, TestCondtion.ToK8sCondition().HasCondition(&testObj.Status))
 
-	assert.Equal(t, false, AnotherTestCondtion.ToKatesCondition().HasCondition(&testObj))
-	assert.Equal(t, false, AnotherTestCondtion.ToKatesCondition().HasCondition(&testObj.Status))
+	assert.Equal(t, false, AnotherTestCondtion.ToK8sCondition().HasCondition(&testObj))
+	assert.Equal(t, false, AnotherTestCondtion.ToK8sCondition().HasCondition(&testObj.Status))
 }
 
 func TestStandardConditionGetStatus(t *testing.T) {
 	testObj := newTestObjStd(TestCondtion)
-	assert.Equal(t, "True", TestCondtion.ToKatesCondition().GetStatus(&testObj))
-	assert.Equal(t, "True", TestCondtion.ToKatesCondition().GetStatus(&testObj.Status))
+	assert.Equal(t, "True", TestCondtion.ToK8sCondition().GetStatus(&testObj))
+	assert.Equal(t, "True", TestCondtion.ToK8sCondition().GetStatus(&testObj.Status))
 
-	assert.Equal(t, "", AnotherTestCondtion.ToKatesCondition().GetStatus(&testObj))
-	assert.Equal(t, "", AnotherTestCondtion.ToKatesCondition().GetStatus(&testObj.Status))
+	assert.Equal(t, "", AnotherTestCondtion.ToK8sCondition().GetStatus(&testObj))
+	assert.Equal(t, "", AnotherTestCondtion.ToK8sCondition().GetStatus(&testObj.Status))
 }
 
 func TestStandardConditionSetStatus(t *testing.T) {
 	testObj := newTestObjStd(TestCondtion)
-	assert.Equal(t, "True", TestCondtion.ToKatesCondition().GetStatus(&testObj))
-	assert.Equal(t, "True", TestCondtion.ToKatesCondition().GetStatus(&testObj.Status))
-	TestCondtion.ToKatesCondition().SetStatus(&testObj, "False")
-	assert.Equal(t, "False", TestCondtion.ToKatesCondition().GetStatus(&testObj))
-	assert.Equal(t, "False", TestCondtion.ToKatesCondition().GetStatus(&testObj.Status))
+	assert.Equal(t, "True", TestCondtion.ToK8sCondition().GetStatus(&testObj))
+	assert.Equal(t, "True", TestCondtion.ToK8sCondition().GetStatus(&testObj.Status))
+	TestCondtion.ToK8sCondition().SetStatus(&testObj, "False")
+	assert.Equal(t, "False", TestCondtion.ToK8sCondition().GetStatus(&testObj))
+	assert.Equal(t, "False", TestCondtion.ToK8sCondition().GetStatus(&testObj.Status))
 
 	assert.Equal(t, "", AnotherTestCondtion.GetStatus(&testObj))
 	assert.Equal(t, "", AnotherTestCondtion.GetStatus(&testObj.Status))
@@ -86,67 +86,67 @@ func TestStandardConditionSetStatus(t *testing.T) {
 
 func TestStandardBoolHelpers(t *testing.T) {
 	testObj := newTestObjStd(TestCondtion)
-	assert.Equal(t, "True", TestCondtion.ToKatesCondition().GetStatus(&testObj))
-	assert.Equal(t, "True", TestCondtion.ToKatesCondition().GetStatus(&testObj.Status))
-	TestCondtion.ToKatesCondition().False(&testObj)
-	assert.Equal(t, "False", TestCondtion.ToKatesCondition().GetStatus(&testObj))
-	assert.Equal(t, "False", TestCondtion.ToKatesCondition().GetStatus(&testObj.Status))
+	assert.Equal(t, "True", TestCondtion.ToK8sCondition().GetStatus(&testObj))
+	assert.Equal(t, "True", TestCondtion.ToK8sCondition().GetStatus(&testObj.Status))
+	TestCondtion.ToK8sCondition().False(&testObj)
+	assert.Equal(t, "False", TestCondtion.ToK8sCondition().GetStatus(&testObj))
+	assert.Equal(t, "False", TestCondtion.ToK8sCondition().GetStatus(&testObj.Status))
 
-	assert.Equal(t, "", AnotherTestCondtion.ToKatesCondition().GetStatus(&testObj))
-	assert.Equal(t, "", AnotherTestCondtion.ToKatesCondition().GetStatus(&testObj.Status))
-	AnotherTestCondtion.ToKatesCondition().True(&testObj)
-	assert.Equal(t, "True", AnotherTestCondtion.ToKatesCondition().GetStatus(&testObj))
-	assert.Equal(t, "True", AnotherTestCondtion.ToKatesCondition().GetStatus(&testObj.Status))
-	AnotherTestCondtion.ToKatesCondition().False(&testObj)
-	assert.Equal(t, "False", AnotherTestCondtion.ToKatesCondition().GetStatus(&testObj))
-	assert.Equal(t, "False", AnotherTestCondtion.ToKatesCondition().GetStatus(&testObj.Status))
+	assert.Equal(t, "", AnotherTestCondtion.ToK8sCondition().GetStatus(&testObj))
+	assert.Equal(t, "", AnotherTestCondtion.ToK8sCondition().GetStatus(&testObj.Status))
+	AnotherTestCondtion.ToK8sCondition().True(&testObj)
+	assert.Equal(t, "True", AnotherTestCondtion.ToK8sCondition().GetStatus(&testObj))
+	assert.Equal(t, "True", AnotherTestCondtion.ToK8sCondition().GetStatus(&testObj.Status))
+	AnotherTestCondtion.ToK8sCondition().False(&testObj)
+	assert.Equal(t, "False", AnotherTestCondtion.ToK8sCondition().GetStatus(&testObj))
+	assert.Equal(t, "False", AnotherTestCondtion.ToK8sCondition().GetStatus(&testObj.Status))
 }
 
 func TestStandardConditionSetStatusBool(t *testing.T) {
 	testObj := newTestObjStd(TestCondtion)
-	assert.Equal(t, "True", TestCondtion.ToKatesCondition().GetStatus(&testObj))
-	assert.Equal(t, "True", TestCondtion.ToKatesCondition().GetStatus(&testObj.Status))
-	TestCondtion.ToKatesCondition().SetStatusBool(&testObj, false)
-	assert.Equal(t, "False", TestCondtion.ToKatesCondition().GetStatus(&testObj))
-	assert.Equal(t, "False", TestCondtion.ToKatesCondition().GetStatus(&testObj.Status))
+	assert.Equal(t, "True", TestCondtion.ToK8sCondition().GetStatus(&testObj))
+	assert.Equal(t, "True", TestCondtion.ToK8sCondition().GetStatus(&testObj.Status))
+	TestCondtion.ToK8sCondition().SetStatusBool(&testObj, false)
+	assert.Equal(t, "False", TestCondtion.ToK8sCondition().GetStatus(&testObj))
+	assert.Equal(t, "False", TestCondtion.ToK8sCondition().GetStatus(&testObj.Status))
 
-	assert.Equal(t, "", AnotherTestCondtion.ToKatesCondition().GetStatus(&testObj))
-	assert.Equal(t, "", AnotherTestCondtion.ToKatesCondition().GetStatus(&testObj.Status))
-	AnotherTestCondtion.ToKatesCondition().SetStatusBool(&testObj, true)
-	assert.Equal(t, "True", AnotherTestCondtion.ToKatesCondition().GetStatus(&testObj))
-	assert.Equal(t, "True", AnotherTestCondtion.ToKatesCondition().GetStatus(&testObj.Status))
+	assert.Equal(t, "", AnotherTestCondtion.ToK8sCondition().GetStatus(&testObj))
+	assert.Equal(t, "", AnotherTestCondtion.ToK8sCondition().GetStatus(&testObj.Status))
+	AnotherTestCondtion.ToK8sCondition().SetStatusBool(&testObj, true)
+	assert.Equal(t, "True", AnotherTestCondtion.ToK8sCondition().GetStatus(&testObj))
+	assert.Equal(t, "True", AnotherTestCondtion.ToK8sCondition().GetStatus(&testObj.Status))
 }
 
 func TestStandardConditionReasonMethods(t *testing.T) {
 	testObj := newTestObjStd(TestCondtion)
-	TestCondtion.ToKatesCondition().SetReason(&testObj, "Because I Said So")
-	assert.Equal(t, "Because I Said So", TestCondtion.ToKatesCondition().GetReason(&testObj))
+	TestCondtion.ToK8sCondition().SetReason(&testObj, "Because I Said So")
+	assert.Equal(t, "Because I Said So", TestCondtion.ToK8sCondition().GetReason(&testObj))
 
-	assert.Equal(t, "", AnotherTestCondtion.ToKatesCondition().GetReason(&testObj))
-	AnotherTestCondtion.ToKatesCondition().SetReason(&testObj, "Because Tom Said So")
-	assert.Equal(t, "Because Tom Said So", AnotherTestCondtion.ToKatesCondition().GetReason(&testObj))
+	assert.Equal(t, "", AnotherTestCondtion.ToK8sCondition().GetReason(&testObj))
+	AnotherTestCondtion.ToK8sCondition().SetReason(&testObj, "Because Tom Said So")
+	assert.Equal(t, "Because Tom Said So", AnotherTestCondtion.ToK8sCondition().GetReason(&testObj))
 }
 
 func TestStandardConditionSetMessageIfBlank(t *testing.T) {
 	testObj := newTestObjStd(TestCondtion)
-	TestCondtion.ToKatesCondition().SetMessageIfBlank(&testObj, "This will be ignored")
+	TestCondtion.ToK8sCondition().SetMessageIfBlank(&testObj, "This will be ignored")
 	assert.NotEqual(t, "This will be ignored", TestCondtion.GetMessage(&testObj))
 
 	assert.Equal(t, "", AnotherTestCondtion.GetMessage(&testObj))
-	AnotherTestCondtion.ToKatesCondition().SetMessageIfBlank(&testObj, "This will be updated")
+	AnotherTestCondtion.ToK8sCondition().SetMessageIfBlank(&testObj, "This will be updated")
 	assert.Equal(t, "This will be updated", AnotherTestCondtion.GetMessage(&testObj))
-	AnotherTestCondtion.ToKatesCondition().SetMessageIfBlank(&testObj, "This will NOT be updated")
+	AnotherTestCondtion.ToK8sCondition().SetMessageIfBlank(&testObj, "This will NOT be updated")
 	assert.Equal(t, "This will be updated", AnotherTestCondtion.GetMessage(&testObj))
 }
 
 func TestStandardConditionMessageMethods(t *testing.T) {
 	testObj := newTestObjStd(TestCondtion)
-	assert.Equal(t, "Hello World", TestCondtion.ToKatesCondition().GetMessage(&testObj))
-	TestCondtion.ToKatesCondition().SetMessage(&testObj, "")
-	assert.Equal(t, "", TestCondtion.ToKatesCondition().GetMessage(&testObj))
+	assert.Equal(t, "Hello World", TestCondtion.ToK8sCondition().GetMessage(&testObj))
+	TestCondtion.ToK8sCondition().SetMessage(&testObj, "")
+	assert.Equal(t, "", TestCondtion.ToK8sCondition().GetMessage(&testObj))
 
-	AnotherTestCondtion.ToKatesCondition().SetMessage(&testObj, "This will be updated")
-	assert.Equal(t, "This will be updated", AnotherTestCondtion.ToKatesCondition().GetMessage(&testObj))
+	AnotherTestCondtion.ToK8sCondition().SetMessage(&testObj, "This will be updated")
+	assert.Equal(t, "This will be updated", AnotherTestCondtion.ToK8sCondition().GetMessage(&testObj))
 }
 
 func TestStandardConditionErrorMethods(t *testing.T) {
@@ -155,22 +155,22 @@ func TestStandardConditionErrorMethods(t *testing.T) {
 	testError := errors.New("some test error")
 
 	testObj := newTestObjStd(TestCondtion)
-	TestCondtion.ToKatesCondition().False(&testObj)
-	SubStatusCondition.ToKatesCondition().False(&testObj)
-	SubStatusCondition.ToKatesCondition().SetError(&testObj, "", testError)
+	TestCondtion.ToK8sCondition().False(&testObj)
+	SubStatusCondition.ToK8sCondition().False(&testObj)
+	SubStatusCondition.ToK8sCondition().SetError(&testObj, "", testError)
 
-	assert.Equal(t, "Error", SubStatusCondition.ToKatesCondition().GetReason(&testObj))
-	assert.Equal(t, "some test error", SubStatusCondition.ToKatesCondition().GetMessage(&testObj))
-	assert.True(t, SubStatusCondition.ToKatesCondition().MatchesError(&testObj, "Error", testError))
-	assert.True(t, SubStatusCondition.ToKatesCondition().MatchesError(&testObj, "", testError))
+	assert.Equal(t, "Error", SubStatusCondition.ToK8sCondition().GetReason(&testObj))
+	assert.Equal(t, "some test error", SubStatusCondition.ToK8sCondition().GetMessage(&testObj))
+	assert.True(t, SubStatusCondition.ToK8sCondition().MatchesError(&testObj, "Error", testError))
+	assert.True(t, SubStatusCondition.ToK8sCondition().MatchesError(&testObj, "", testError))
 
-	SubStatusCondition.ToKatesCondition().SetError(&testObj, "Because it Broke", testError)
-	assert.False(t, SubStatusCondition.ToKatesCondition().MatchesError(&testObj, "", testError))
-	assert.True(t, SubStatusCondition.ToKatesCondition().MatchesError(&testObj, "Because it Broke", testError))
-	assert.False(t, SubStatusCondition.ToKatesCondition().MatchesError(&testObj, "Because something else Broke", testError))
+	SubStatusCondition.ToK8sCondition().SetError(&testObj, "Because it Broke", testError)
+	assert.False(t, SubStatusCondition.ToK8sCondition().MatchesError(&testObj, "", testError))
+	assert.True(t, SubStatusCondition.ToK8sCondition().MatchesError(&testObj, "Because it Broke", testError))
+	assert.False(t, SubStatusCondition.ToK8sCondition().MatchesError(&testObj, "Because something else Broke", testError))
 
-	SubStatusCondition.ToKatesCondition().SetError(&testObj, "Because something else Broke", nil)
-	assert.False(t, SubStatusCondition.ToKatesCondition().MatchesError(&testObj, "Because something else Broke", testError))
-	assert.True(t, SubStatusCondition.ToKatesCondition().MatchesError(&testObj, "Because something else Broke", nil))
+	SubStatusCondition.ToK8sCondition().SetError(&testObj, "Because something else Broke", nil)
+	assert.False(t, SubStatusCondition.ToK8sCondition().MatchesError(&testObj, "Because something else Broke", testError))
+	assert.True(t, SubStatusCondition.ToK8sCondition().MatchesError(&testObj, "Because something else Broke", nil))
 
 }

--- a/pkg/condition/types/main.go
+++ b/pkg/condition/types/main.go
@@ -42,3 +42,17 @@ type Condition interface {
 	SetMessage(obj interface{}, msg string)
 	SetMessageIfBlank(obj interface{}, message string)
 }
+
+type FluentCondition interface {
+	Target(obj interface{}) FluentCondition
+	SetStatus(status string) FluentCondition
+	True() FluentCondition
+	False() FluentCondition
+	Unknown() FluentCondition
+	SetStatusBool(val bool) FluentCondition
+	SetError(reason string, err error) FluentCondition
+	SetReason(reason string) FluentCondition
+	SetMessage(message string) FluentCondition
+	SetMessageIfBlank(message string) FluentCondition
+	Apply(obj interface{}) bool
+}

--- a/pkg/condition/types/main.go
+++ b/pkg/condition/types/main.go
@@ -1,5 +1,7 @@
 package types
 
+import "sigs.k8s.io/controller-runtime/pkg/client"
+
 // LegacyCondition maps to logic related to the wrangler GenericCondition
 type LegacyCondition interface {
 	GetStatus(obj interface{}) string
@@ -24,27 +26,27 @@ type LegacyCondition interface {
 
 // Condition maps to logic related to the k8s native KEP-1623
 type Condition interface {
-	HasCondition(obj interface{}) bool
-	GetStatus(obj interface{}) string
-	SetStatus(obj interface{}, status string)
-	True(obj interface{})
-	IsTrue(obj interface{}) bool
-	False(obj interface{})
-	IsFalse(obj interface{}) bool
-	Unknown(obj interface{})
-	IsUnknown(obj interface{}) bool
-	SetStatusBool(obj interface{}, val bool)
-	SetError(obj interface{}, reason string, err error)
-	MatchesError(obj interface{}, reason string, err error) bool
-	GetReason(obj interface{}) string
-	SetReason(obj interface{}, reason string)
-	GetMessage(obj interface{}) string
-	SetMessage(obj interface{}, msg string)
-	SetMessageIfBlank(obj interface{}, message string)
+	HasCondition(obj client.Object) bool
+	GetStatus(obj client.Object) string
+	SetStatus(obj client.Object, status string)
+	True(obj client.Object)
+	IsTrue(obj client.Object) bool
+	False(obj client.Object)
+	IsFalse(obj client.Object) bool
+	Unknown(obj client.Object)
+	IsUnknown(obj client.Object) bool
+	SetStatusBool(obj client.Object, val bool)
+	SetError(obj client.Object, reason string, err error)
+	MatchesError(obj client.Object, reason string, err error) bool
+	GetReason(obj client.Object) string
+	SetReason(obj client.Object, reason string)
+	GetMessage(obj client.Object) string
+	SetMessage(obj client.Object, msg string)
+	SetMessageIfBlank(obj client.Object, message string)
 }
 
 type FluentCondition interface {
-	Target(obj interface{}) FluentCondition
+	Target(obj client.Object) FluentCondition
 	SetStatus(status string) FluentCondition
 	True() FluentCondition
 	False() FluentCondition
@@ -54,5 +56,5 @@ type FluentCondition interface {
 	SetReason(reason string) FluentCondition
 	SetMessage(message string) FluentCondition
 	SetMessageIfBlank(message string) FluentCondition
-	Apply(obj interface{}) bool
+	Apply(obj client.Object) bool
 }

--- a/pkg/condition/types/main.go
+++ b/pkg/condition/types/main.go
@@ -1,0 +1,44 @@
+package types
+
+// LegacyCondition maps to logic related to the wrangler GenericCondition
+type LegacyCondition interface {
+	GetStatus(obj interface{}) string
+	SetStatus(obj interface{}, status string)
+	SetStatusBool(obj interface{}, val bool)
+	True(obj interface{})
+	IsTrue(obj interface{}) bool
+	False(obj interface{})
+	IsFalse(obj interface{}) bool
+	Unknown(obj interface{})
+	IsUnknown(obj interface{}) bool
+	LastUpdated(obj interface{}, ts string)
+	GetLastUpdated(obj interface{}) string
+	SetError(obj interface{}, reason string, err error)
+	MatchesError(obj interface{}, reason string, err error) bool
+	GetReason(obj interface{}) string
+	Reason(obj interface{}, reason string)
+	GetMessage(obj interface{}) string
+	Message(obj interface{}, msg string)
+	SetMessageIfBlank(obj interface{}, message string)
+}
+
+// Condition maps to logic related to the k8s native KEP-1623
+type Condition interface {
+	HasCondition(obj interface{}) bool
+	GetStatus(obj interface{}) string
+	SetStatus(obj interface{}, status string)
+	True(obj interface{})
+	IsTrue(obj interface{}) bool
+	False(obj interface{})
+	IsFalse(obj interface{}) bool
+	Unknown(obj interface{})
+	IsUnknown(obj interface{}) bool
+	SetStatusBool(obj interface{}, val bool)
+	SetError(obj interface{}, reason string, err error)
+	MatchesError(obj interface{}, reason string, err error) bool
+	GetReason(obj interface{}) string
+	SetReason(obj interface{}, reason string)
+	GetMessage(obj interface{}) string
+	SetMessage(obj interface{}, msg string)
+	SetMessageIfBlank(obj interface{}, message string)
+}

--- a/pkg/genericcondition/condition.go
+++ b/pkg/genericcondition/condition.go
@@ -1,6 +1,10 @@
 package genericcondition
 
-import v1 "k8s.io/api/core/v1"
+import (
+	v1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"time"
+)
 
 type GenericCondition struct {
 	// Type of cluster condition.
@@ -15,4 +19,18 @@ type GenericCondition struct {
 	Reason string `json:"reason,omitempty"`
 	// Human-readable message indicating details about last transition
 	Message string `json:"message,omitempty"`
+}
+
+// ToK8sCondition will translate an existing condition into a k8s condition (essentially drops LastUpdatedTime)
+func (g GenericCondition) ToK8sCondition() metav1.Condition {
+	lastTransitionTime, _ := time.Parse(time.RFC3339, g.LastTransitionTime)
+
+	return metav1.Condition{
+		Type:   g.Type,
+		Status: metav1.ConditionStatus(g.Status),
+		// ObservedGeneration: nil, // Ideally set this to the current generation at time of conversion
+		LastTransitionTime: metav1.NewTime(lastTransitionTime),
+		Reason:             g.Reason,
+		Message:            g.Message,
+	}
 }


### PR DESCRIPTION
# Why?

Since Wrangler's creation around 2019 (when the existing `Cond` was created) a lot has changed. One of those significant changes was [KEP-1623](https://github.com/kubernetes/enhancements/blob/master/keps/sig-api-machinery/1623-standardize-conditions/README.md) - essentially a standard for Conditions in k8s.

The existing Wrangler/Rancher style of Conditons is very similar to the new standard. This allows potential for adding the KEP support in an opt-in manner; when comparing Wrangler and KEP/k8s flavored `Condition` the primary differences are:

- Slightly different, but compatible `Status` field type (`api/core/v1` vs `apimachinery's meta/v1`)
- Wrangler's Condition has a `LastUpdatedTime`
- k8s Condition has strict behavior around updating `LastTransitionTime`
- k8s Condition `LastTransitionTime` field type is `metav1.Time`
- Wrangler allows `Reason` and `Message` to be empty and omitted; k8s requires a non-empty `Reason` value, and requires `Message` but allows empty (`""`) values.
- k8s Condition includes an optional `ObservedGeneration` field to track resource generation.
- k8s Condition also includes `protobuf` annotations

## How to use?

Just like the existing implementation you will create a `Conditions` field on your status. However the first difference will be how you define that fields type and annotations. It should use:

```go
	// +listType=map
	// +listMapKey=type
	// +patchStrategy=merge
	// +patchMergeKey=type
	// +optional
	Conditions                 []metav1.Condition      `json:"conditions,omitempty" patchStrategy:"merge" patchMergeKey:"type" protobuf:"bytes,1,rep,name=conditions"`
```

Then, when you're in your controller and want to use a condition you do it exactly the same as today - for the most part - but with the addition of one extra call `.ToK8sCondition()`. The main caveat of "for the most part" is that the new implementation doesn't use the exact same interface as the wrangler flavor condition.

Specifically:

- `Message(obj interface{}, msg string)` changed to `SetMessage(obj interface{}, msg string)`
- `Reason(obj interface{}, reason string)` changed to `SetReason(obj interface{}, reason string)`
- Original style condition added `HasCondition(obj interface{}) bool`
- (Optional, as in can be removed) Fluent API that's much nicer than the backward compatible API [parity of unit coverage for fluent API is a WIP]


Here is a more complete example of using a condition:

```go
    ResourceConditionReady Cond = "Ready"

// Via Fluent API
    ResourceConditionReady.ToK8sFluentCondition(&myCrdObj).False().SetMessage("Hello world").Apply(&myCrdObj)

// Or via Wrangler compatible KEP1623 updated API
    ResourceConditionReady.ToK8sCondition().False(&myCrdObj)
    ResourceConditionReady.ToK8sCondition().SetMessage(&myCrdObj, "Hello world")

// Reference: Wrangler API
    ResourceConditionReady.False(&myCrdObj)
    ResourceConditionReady.SetMessage(&myCrdObj, "Hello world")
```

---
If accepted, I also have backport [branch ready for V2](https://github.com/rancher/wrangler/compare/release/v2...mallardduck:rancher-wrangler:v2-kep1623?expand=1); and could likely make a backport for V1 as well.

---

### Breaking Changes?

Highly Unlikely. I've come to this conclusion via using golang experimental `apidiff` tool. Note that when I checked this aspect for both main and V2 the results were the same. So I will only show the work for the `main` branch checks I did. Here's the steps I did to get this result:

```bash
± |kep1623 → origin {1} ?:1 ✗| → apidiff -w ./new ./pkg/condition/
± |kep1623 → origin {1} ?:2 ✗| → git checkout main
± |main → upstream {1} ?:2 ✗| → apidiff -w ./main ./pkg/condition/
± |main → upstream {1} ?:3 ✗| → apidiff main new
Compatible changes:
- Cond.HasCondition: added
- Cond.Name: added
- Cond.SetMessage: added
- Cond.SetReason: added
- Cond.ToFluentBuilder: added
- Cond.ToK8sCondition: added
- MetaV1ConditionFluentBuilder: added
- MetaV1ConditionHandler: added
```

Doing the same for `genericcondition` pkg:

```bash
Compatible changes:
- GenericCondition.ToK8sCondition: added
```

### What if an existing CRD adopts the new KEP based Conditions though?
I have tested with BRO here: https://github.com/rancher/backup-restore-operator/pull/763

The results of my tests are that:
- Any existing resource with old style conditions will parse into new conditions fine,
- The `LastUpdatedAt` field is lost as expected - **this would be a breaking change** likely workaround is just using `LastTransitionedAt` _that still introduces behavior changes though_
  - To understand `LastTransitionedAt` updates review: [k8s Condition Setting Code](https://github.com/kubernetes/apimachinery/blob/v0.32.3/pkg/api/meta/conditions.go#L31) and the notes above it
- When the resource is first updated after this change, any conditions will be updated to include the new required fields.

So to be more succinct, the main conditions where you **must use caution** are:
- Your current resource controller logic tightly depends on the `LastUpdatedAt` time of conditions.
- Your current Condition sets non-CamelCase `Reason` values
  - Maybe not deal breaker; the `Reason` defaults to `Created` - so this will be filled in when Wrangler flavor updated
