### PR TITLE
[main] Maintain app.catalog.cattle.io namespace when summarizing relatonship

### DIFF
--- a/pkg/summary/cattletypes.go
+++ b/pkg/summary/cattletypes.go
@@ -34,6 +34,7 @@ func checkRelease(obj data.Object, _ []Condition, summary Summary) Summary {
 	for _, resources := range obj.Slice("spec", "resources") {
 		summary.Relationships = append(summary.Relationships, Relationship{
 			Name:       resources.String("name"),
+			Namespace:  resources.String("namespace"),
 			Kind:       resources.String("kind"),
 			APIVersion: resources.String("apiVersion"),
 			Type:       "helmresource",


### PR DESCRIPTION
https://github.com/rancher/rancher/issues/51065

When summarizing a `app.catalog.cattle.io`  and reconciling the relationships for the k8s resources listed in its `.spec.resources` field we drop the `namespace` field and later assign it to the namespace of the `app.catalog.cattle.io` in steve. This leads to steve looking at the wrong namespaces when determing the relationship for these resources, thus leading to an incorrect relationship status.