### PR TITLE
47898 OnLeader should return any error returned by the called functions.

### DIFF
--- a/pkg/leader/manager.go
+++ b/pkg/leader/manager.go
@@ -3,7 +3,6 @@ package leader
 import (
 	"context"
 	"sync"
-	"time"
 
 	"github.com/sirupsen/logrus"
 	"k8s.io/client-go/kubernetes"
@@ -47,13 +46,10 @@ func (m *Manager) Start(ctx context.Context) {
 func (m *Manager) OnLeader(f func(ctx context.Context) error) {
 	go func() {
 		<-m.leaderChan
-		for {
-			if err := f(m.leaderCTX); err != nil {
-				logrus.Errorf("failed to call leader func: %v", err)
-				time.Sleep(5 * time.Second)
-				continue
-			}
-			break
+		if err := f(m.leaderCTX); err != nil {
+			logrus.Errorf("failed to call leader func: %v", err)
+		} else {
+			logrus.Infof("leader func executed successfully")
 		}
 	}()
 }


### PR DESCRIPTION
### **Fixes:** [#47898]

### **Problem**
The Rancher system experienced panics during startup due to a non-idempotent OnLeader handler. The existing code included a retry mechanism (a for loop) that repeatedly executed this handler. Since the handler was not designed to be idempotent (meaning it produces the same result regardless of how many times it's run), retrying it after an error exacerbated the issue, leading to crashes rather than graceful error handling. The core problem was the mismatch between the handler's non-idempotent nature and the code's assumption of idempotency through its retry logic.

### **Solution**
The proposed solution addresses the problem by removing the retry mechanism. Instead of the for loop that re-attempts the f(m.leaderCTX) call, the fix executes the leader function only once. If an error occurs during this single execution, it's logged using logrus.Errorf. If the function executes successfully, a success message is logged using logrus.Infof. This change ensures that non-idempotent operations are not retried, allowing errors to be immediately visible in the logs without causing further panics due to repeated execution of the faulty handler.

###**Tests**

- Leader Re-election (if applicable to Rancher's leader election):

**Test:** If Rancher's leader election process can involve a leader stepping down and a new one being elected, test this scenario to ensure the OnLeader handler is correctly invoked for the new leader and the fix still holds.

**Expected Outcome:** The handler should execute once for the new leader, logging success or failure appropriately without panics or retries.

- Concurrency/Stress Test:

**Test:** Simulate high load during Rancher startup to stress the leader election and handler execution.

**Expected Outcome:** The system should remain stable, and any errors should be logged gracefully without leading to crashes, confirming the removal of the retry mechanism prevents cascading failures.