### PR TITLE
Use watchlist with summary informer only if client supports it

### DIFF
--- a/pkg/summary/informer/informer_test.go
+++ b/pkg/summary/informer/informer_test.go
@@ -1,0 +1,247 @@
+package informer
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/rancher/wrangler/v3/pkg/summary"
+	"github.com/rancher/wrangler/v3/pkg/summary/client"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/apimachinery/pkg/watch"
+	"k8s.io/client-go/tools/cache"
+)
+
+var _ client.ExtendedInterface = (*mockClient)(nil)
+
+type mockClient struct {
+	listCalled  chan struct{}
+	watchCalled chan struct{}
+}
+
+func (m *mockClient) Resource(resource schema.GroupVersionResource) client.NamespaceableResourceInterface {
+	return m
+}
+
+func (m *mockClient) ResourceWithOptions(resource schema.GroupVersionResource, opts *client.Options) client.NamespaceableResourceInterface {
+	return m
+}
+
+func (m *mockClient) Namespace(string) client.ResourceInterface {
+	return m
+}
+
+func (m *mockClient) List(ctx context.Context, opts metav1.ListOptions) (*summary.SummarizedObjectList, error) {
+	if m.listCalled != nil {
+		m.listCalled <- struct{}{}
+	}
+	return &summary.SummarizedObjectList{
+		ListMeta: metav1.ListMeta{
+			ResourceVersion: "1",
+		},
+	}, nil
+}
+
+func (m *mockClient) Watch(ctx context.Context, opts metav1.ListOptions) (watch.Interface, error) {
+	if m.watchCalled != nil {
+		m.watchCalled <- struct{}{}
+	}
+	return watch.NewFake(), nil
+}
+
+type mockClientUnsupported struct {
+	mockClient
+}
+
+func (m *mockClientUnsupported) IsWatchListSemanticsUnSupported() bool {
+	return true
+}
+
+type mockClientSupported struct {
+	mockClient
+}
+
+func (m *mockClientSupported) IsWatchListSemanticsUnSupported() bool {
+	return false
+}
+
+func TestNewFilteredSummaryInformer_WatchListSupport(t *testing.T) {
+	gvr := schema.GroupVersionResource{Group: "test", Version: "v1", Resource: "tests"}
+	namespace := "default"
+
+	tests := []struct {
+		name        string
+		client      client.Interface
+		expectList  bool
+		expectWatch bool
+	}{
+		{
+			name: "Client supporting watchlist (default)",
+			client: &mockClient{
+				listCalled:  make(chan struct{}, 1),
+				watchCalled: make(chan struct{}, 1),
+			},
+			expectList: false,
+		},
+		{
+			name: "Client explicitly supporting watchlist",
+			client: &mockClientSupported{
+				mockClient: mockClient{
+					listCalled:  make(chan struct{}, 1),
+					watchCalled: make(chan struct{}, 1),
+				},
+			},
+			expectList: false,
+		},
+		{
+			name: "Client explicitly NOT supporting watchlist",
+			client: &mockClientUnsupported{
+				mockClient: mockClient{
+					listCalled:  make(chan struct{}, 1),
+					watchCalled: make(chan struct{}, 1),
+				},
+			},
+			expectList: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			informer := NewFilteredSummaryInformer(tt.client, gvr, namespace, 0, cache.Indexers{}, nil)
+			stopCh := make(chan struct{})
+			defer close(stopCh)
+
+			go informer.Informer().Run(stopCh)
+
+			// Wait for either List or Watch to be called
+			var mc *mockClient
+			switch c := tt.client.(type) {
+			case *mockClient:
+				mc = c
+			case *mockClientSupported:
+				mc = &c.mockClient
+			case *mockClientUnsupported:
+				mc = &c.mockClient
+			}
+
+			time.Sleep(100 * time.Millisecond)
+			listCalled := false
+			watchCalled := false
+
+			select {
+			case <-time.After(100 * time.Millisecond):
+			case <-mc.listCalled:
+				listCalled = true
+			}
+
+			select {
+			case <-time.After(100 * time.Millisecond):
+			case <-mc.watchCalled:
+				watchCalled = true
+			}
+
+			if tt.expectList && !listCalled {
+				t.Fatal("Expected list call but didn't get it")
+			}
+
+			if !tt.expectList && listCalled {
+				t.Fatal("Expected NO list call")
+			}
+
+			if !watchCalled {
+				t.Fatal("Expected watch call but didn't get it")
+			}
+		})
+	}
+}
+
+func TestNewFilteredSummaryInformerWithOptions_WatchListSupport(t *testing.T) {
+	gvr := schema.GroupVersionResource{Group: "test", Version: "v1", Resource: "tests"}
+	namespace := "default"
+
+	tests := []struct {
+		name        string
+		client      client.ExtendedInterface
+		expectList  bool
+		expectWatch bool
+	}{
+		{
+			name: "Client supporting watchlist (default)",
+			client: &mockClient{
+				listCalled:  make(chan struct{}, 1),
+				watchCalled: make(chan struct{}, 1),
+			},
+			expectList: false,
+		},
+		{
+			name: "Client explicitly supporting watchlist",
+			client: &mockClientSupported{
+				mockClient: mockClient{
+					listCalled:  make(chan struct{}, 1),
+					watchCalled: make(chan struct{}, 1),
+				},
+			},
+			expectList: false,
+		},
+		{
+			name: "Client explicitly NOT supporting watchlist",
+			client: &mockClientUnsupported{
+				mockClient: mockClient{
+					listCalled:  make(chan struct{}, 1),
+					watchCalled: make(chan struct{}, 1),
+				},
+			},
+			expectList: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			informer := NewFilteredSummaryInformerWithOptions(tt.client, gvr, nil, namespace, 0, cache.Indexers{}, nil)
+			stopCh := make(chan struct{})
+			defer close(stopCh)
+
+			go informer.Informer().Run(stopCh)
+
+			// Wait for either List or Watch to be called
+			var mc *mockClient
+			switch c := tt.client.(type) {
+			case *mockClient:
+				mc = c
+			case *mockClientSupported:
+				mc = &c.mockClient
+			case *mockClientUnsupported:
+				mc = &c.mockClient
+			}
+
+			time.Sleep(100 * time.Millisecond)
+			listCalled := false
+			watchCalled := false
+
+			select {
+			case <-time.After(100 * time.Millisecond):
+			case <-mc.listCalled:
+				listCalled = true
+			}
+
+			select {
+			case <-time.After(100 * time.Millisecond):
+			case <-mc.watchCalled:
+				watchCalled = true
+			}
+
+			if tt.expectList && !listCalled {
+				t.Fatal("Expected list call but didn't get it")
+			}
+
+			if !tt.expectList && listCalled {
+				t.Fatal("Expected NO list call")
+			}
+
+			if !watchCalled {
+				t.Fatal("Expected watch call but didn't get it")
+			}
+		})
+	}
+}

--- a/pkg/summary/informer/watchlist.go
+++ b/pkg/summary/informer/watchlist.go
@@ -1,0 +1,54 @@
+package informer
+
+import (
+	"k8s.io/client-go/tools/cache"
+)
+
+// Copied from Kubernetes' source, only available in k8s 1.35
+
+type listWatcherWithWatchListSemanticsWrapper struct {
+	*cache.ListWatch
+
+	// unsupportedWatchListSemantics indicates whether a client explicitly does NOT support
+	// WatchList semantics.
+	//
+	// Over the years, unit tests in kube have been written in many different ways.
+	// After enabling the WatchListClient feature by default, existing tests started failing.
+	// To avoid breaking lots of existing client-go users after upgrade,
+	// we introduced this field as an opt-in.
+	//
+	// When true, the reflector disables WatchList even if the feature gate is enabled.
+	unsupportedWatchListSemantics bool
+}
+
+func (lw *listWatcherWithWatchListSemanticsWrapper) IsWatchListSemanticsUnSupported() bool {
+	return lw.unsupportedWatchListSemantics
+}
+
+// toListWatcherWithWatchListSemantics returns a ListerWatcher
+// that knows whether the provided client explicitly
+// does NOT support the WatchList semantics. This allows Reflectors
+// to adapt their behavior based on client capabilities.
+func toListWatcherWithWatchListSemantics(lw *cache.ListWatch, client any) cache.ListerWatcher {
+	return &listWatcherWithWatchListSemanticsWrapper{
+		lw,
+		doesClientNotSupportWatchListSemantics(client),
+	}
+}
+
+type unSupportedWatchListSemantics interface {
+	IsWatchListSemanticsUnSupported() bool
+}
+
+// doesClientNotSupportWatchListSemantics reports whether the given client
+// does NOT support WatchList semantics.
+//
+// A client does NOT support WatchList only if
+// it implements `IsWatchListSemanticsUnSupported` and that returns true.
+func doesClientNotSupportWatchListSemantics(client any) bool {
+	lw, ok := client.(unSupportedWatchListSemantics)
+	if !ok {
+		return false
+	}
+	return lw.IsWatchListSemanticsUnSupported()
+}


### PR DESCRIPTION
# Issue https://github.com/rancher/rancher/issues/53854

When using a `cache.ListWatch`, Kubernetes assumes it will support the WatchList feature. However, that is not always the case since the client miht not support the new WatchList semantic.

The client-go library now includes a [function](https://github.com/kubernetes/client-go/blob/9bcb69436287b966d0c5c195efef00aed921fb1b/tools/cache/listwatch.go#L157) and an [interface](https://github.com/kubernetes/client-go/blob/9bcb69436287b966d0c5c195efef00aed921fb1b/util/watchlist/watch_list.go#L84-L86) that allows a client to opt-out of the WatchList feature if it doesn't support it.

We need this in Rancher to workaround a bug during an upgrade path. It's still useful imo for wrangler anyway.

Here's the accompanying PR that makes use of this: https://github.com/rancher/steve/pull/1034/.