### PR TITLE
Implement DeleteCollection.

### DIFF
--- a/pkg/crd/mockCRDClient_test.go
+++ b/pkg/crd/mockCRDClient_test.go
@@ -25,6 +25,7 @@ import (
 type MockCustomResourceDefinitionInterface struct {
 	ctrl     *gomock.Controller
 	recorder *MockCustomResourceDefinitionInterfaceMockRecorder
+	isgomock struct{}
 }
 
 // MockCustomResourceDefinitionInterfaceMockRecorder is the mock recorder for MockCustomResourceDefinitionInterface.
@@ -45,113 +46,113 @@ func (m *MockCustomResourceDefinitionInterface) EXPECT() *MockCustomResourceDefi
 }
 
 // Apply mocks base method.
-func (m *MockCustomResourceDefinitionInterface) Apply(arg0 context.Context, arg1 *v10.CustomResourceDefinitionApplyConfiguration, arg2 v11.ApplyOptions) (*v1.CustomResourceDefinition, error) {
+func (m *MockCustomResourceDefinitionInterface) Apply(ctx context.Context, customResourceDefinition *v10.CustomResourceDefinitionApplyConfiguration, opts v11.ApplyOptions) (*v1.CustomResourceDefinition, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "Apply", arg0, arg1, arg2)
+	ret := m.ctrl.Call(m, "Apply", ctx, customResourceDefinition, opts)
 	ret0, _ := ret[0].(*v1.CustomResourceDefinition)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // Apply indicates an expected call of Apply.
-func (mr *MockCustomResourceDefinitionInterfaceMockRecorder) Apply(arg0, arg1, arg2 any) *gomock.Call {
+func (mr *MockCustomResourceDefinitionInterfaceMockRecorder) Apply(ctx, customResourceDefinition, opts any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Apply", reflect.TypeOf((*MockCustomResourceDefinitionInterface)(nil).Apply), arg0, arg1, arg2)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Apply", reflect.TypeOf((*MockCustomResourceDefinitionInterface)(nil).Apply), ctx, customResourceDefinition, opts)
 }
 
 // ApplyStatus mocks base method.
-func (m *MockCustomResourceDefinitionInterface) ApplyStatus(arg0 context.Context, arg1 *v10.CustomResourceDefinitionApplyConfiguration, arg2 v11.ApplyOptions) (*v1.CustomResourceDefinition, error) {
+func (m *MockCustomResourceDefinitionInterface) ApplyStatus(ctx context.Context, customResourceDefinition *v10.CustomResourceDefinitionApplyConfiguration, opts v11.ApplyOptions) (*v1.CustomResourceDefinition, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "ApplyStatus", arg0, arg1, arg2)
+	ret := m.ctrl.Call(m, "ApplyStatus", ctx, customResourceDefinition, opts)
 	ret0, _ := ret[0].(*v1.CustomResourceDefinition)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // ApplyStatus indicates an expected call of ApplyStatus.
-func (mr *MockCustomResourceDefinitionInterfaceMockRecorder) ApplyStatus(arg0, arg1, arg2 any) *gomock.Call {
+func (mr *MockCustomResourceDefinitionInterfaceMockRecorder) ApplyStatus(ctx, customResourceDefinition, opts any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ApplyStatus", reflect.TypeOf((*MockCustomResourceDefinitionInterface)(nil).ApplyStatus), arg0, arg1, arg2)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ApplyStatus", reflect.TypeOf((*MockCustomResourceDefinitionInterface)(nil).ApplyStatus), ctx, customResourceDefinition, opts)
 }
 
 // Create mocks base method.
-func (m *MockCustomResourceDefinitionInterface) Create(arg0 context.Context, arg1 *v1.CustomResourceDefinition, arg2 v11.CreateOptions) (*v1.CustomResourceDefinition, error) {
+func (m *MockCustomResourceDefinitionInterface) Create(ctx context.Context, customResourceDefinition *v1.CustomResourceDefinition, opts v11.CreateOptions) (*v1.CustomResourceDefinition, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "Create", arg0, arg1, arg2)
+	ret := m.ctrl.Call(m, "Create", ctx, customResourceDefinition, opts)
 	ret0, _ := ret[0].(*v1.CustomResourceDefinition)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // Create indicates an expected call of Create.
-func (mr *MockCustomResourceDefinitionInterfaceMockRecorder) Create(arg0, arg1, arg2 any) *gomock.Call {
+func (mr *MockCustomResourceDefinitionInterfaceMockRecorder) Create(ctx, customResourceDefinition, opts any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Create", reflect.TypeOf((*MockCustomResourceDefinitionInterface)(nil).Create), arg0, arg1, arg2)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Create", reflect.TypeOf((*MockCustomResourceDefinitionInterface)(nil).Create), ctx, customResourceDefinition, opts)
 }
 
 // Delete mocks base method.
-func (m *MockCustomResourceDefinitionInterface) Delete(arg0 context.Context, arg1 string, arg2 v11.DeleteOptions) error {
+func (m *MockCustomResourceDefinitionInterface) Delete(ctx context.Context, name string, opts v11.DeleteOptions) error {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "Delete", arg0, arg1, arg2)
+	ret := m.ctrl.Call(m, "Delete", ctx, name, opts)
 	ret0, _ := ret[0].(error)
 	return ret0
 }
 
 // Delete indicates an expected call of Delete.
-func (mr *MockCustomResourceDefinitionInterfaceMockRecorder) Delete(arg0, arg1, arg2 any) *gomock.Call {
+func (mr *MockCustomResourceDefinitionInterfaceMockRecorder) Delete(ctx, name, opts any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Delete", reflect.TypeOf((*MockCustomResourceDefinitionInterface)(nil).Delete), arg0, arg1, arg2)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Delete", reflect.TypeOf((*MockCustomResourceDefinitionInterface)(nil).Delete), ctx, name, opts)
 }
 
 // DeleteCollection mocks base method.
-func (m *MockCustomResourceDefinitionInterface) DeleteCollection(arg0 context.Context, arg1 v11.DeleteOptions, arg2 v11.ListOptions) error {
+func (m *MockCustomResourceDefinitionInterface) DeleteCollection(ctx context.Context, opts v11.DeleteOptions, listOpts v11.ListOptions) error {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "DeleteCollection", arg0, arg1, arg2)
+	ret := m.ctrl.Call(m, "DeleteCollection", ctx, opts, listOpts)
 	ret0, _ := ret[0].(error)
 	return ret0
 }
 
 // DeleteCollection indicates an expected call of DeleteCollection.
-func (mr *MockCustomResourceDefinitionInterfaceMockRecorder) DeleteCollection(arg0, arg1, arg2 any) *gomock.Call {
+func (mr *MockCustomResourceDefinitionInterfaceMockRecorder) DeleteCollection(ctx, opts, listOpts any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DeleteCollection", reflect.TypeOf((*MockCustomResourceDefinitionInterface)(nil).DeleteCollection), arg0, arg1, arg2)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DeleteCollection", reflect.TypeOf((*MockCustomResourceDefinitionInterface)(nil).DeleteCollection), ctx, opts, listOpts)
 }
 
 // Get mocks base method.
-func (m *MockCustomResourceDefinitionInterface) Get(arg0 context.Context, arg1 string, arg2 v11.GetOptions) (*v1.CustomResourceDefinition, error) {
+func (m *MockCustomResourceDefinitionInterface) Get(ctx context.Context, name string, opts v11.GetOptions) (*v1.CustomResourceDefinition, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "Get", arg0, arg1, arg2)
+	ret := m.ctrl.Call(m, "Get", ctx, name, opts)
 	ret0, _ := ret[0].(*v1.CustomResourceDefinition)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // Get indicates an expected call of Get.
-func (mr *MockCustomResourceDefinitionInterfaceMockRecorder) Get(arg0, arg1, arg2 any) *gomock.Call {
+func (mr *MockCustomResourceDefinitionInterfaceMockRecorder) Get(ctx, name, opts any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Get", reflect.TypeOf((*MockCustomResourceDefinitionInterface)(nil).Get), arg0, arg1, arg2)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Get", reflect.TypeOf((*MockCustomResourceDefinitionInterface)(nil).Get), ctx, name, opts)
 }
 
 // List mocks base method.
-func (m *MockCustomResourceDefinitionInterface) List(arg0 context.Context, arg1 v11.ListOptions) (*v1.CustomResourceDefinitionList, error) {
+func (m *MockCustomResourceDefinitionInterface) List(ctx context.Context, opts v11.ListOptions) (*v1.CustomResourceDefinitionList, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "List", arg0, arg1)
+	ret := m.ctrl.Call(m, "List", ctx, opts)
 	ret0, _ := ret[0].(*v1.CustomResourceDefinitionList)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // List indicates an expected call of List.
-func (mr *MockCustomResourceDefinitionInterfaceMockRecorder) List(arg0, arg1 any) *gomock.Call {
+func (mr *MockCustomResourceDefinitionInterfaceMockRecorder) List(ctx, opts any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "List", reflect.TypeOf((*MockCustomResourceDefinitionInterface)(nil).List), arg0, arg1)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "List", reflect.TypeOf((*MockCustomResourceDefinitionInterface)(nil).List), ctx, opts)
 }
 
 // Patch mocks base method.
-func (m *MockCustomResourceDefinitionInterface) Patch(arg0 context.Context, arg1 string, arg2 types.PatchType, arg3 []byte, arg4 v11.PatchOptions, arg5 ...string) (*v1.CustomResourceDefinition, error) {
+func (m *MockCustomResourceDefinitionInterface) Patch(ctx context.Context, name string, pt types.PatchType, data []byte, opts v11.PatchOptions, subresources ...string) (*v1.CustomResourceDefinition, error) {
 	m.ctrl.T.Helper()
-	varargs := []any{arg0, arg1, arg2, arg3, arg4}
-	for _, a := range arg5 {
+	varargs := []any{ctx, name, pt, data, opts}
+	for _, a := range subresources {
 		varargs = append(varargs, a)
 	}
 	ret := m.ctrl.Call(m, "Patch", varargs...)
@@ -161,53 +162,53 @@ func (m *MockCustomResourceDefinitionInterface) Patch(arg0 context.Context, arg1
 }
 
 // Patch indicates an expected call of Patch.
-func (mr *MockCustomResourceDefinitionInterfaceMockRecorder) Patch(arg0, arg1, arg2, arg3, arg4 any, arg5 ...any) *gomock.Call {
+func (mr *MockCustomResourceDefinitionInterfaceMockRecorder) Patch(ctx, name, pt, data, opts any, subresources ...any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	varargs := append([]any{arg0, arg1, arg2, arg3, arg4}, arg5...)
+	varargs := append([]any{ctx, name, pt, data, opts}, subresources...)
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Patch", reflect.TypeOf((*MockCustomResourceDefinitionInterface)(nil).Patch), varargs...)
 }
 
 // Update mocks base method.
-func (m *MockCustomResourceDefinitionInterface) Update(arg0 context.Context, arg1 *v1.CustomResourceDefinition, arg2 v11.UpdateOptions) (*v1.CustomResourceDefinition, error) {
+func (m *MockCustomResourceDefinitionInterface) Update(ctx context.Context, customResourceDefinition *v1.CustomResourceDefinition, opts v11.UpdateOptions) (*v1.CustomResourceDefinition, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "Update", arg0, arg1, arg2)
+	ret := m.ctrl.Call(m, "Update", ctx, customResourceDefinition, opts)
 	ret0, _ := ret[0].(*v1.CustomResourceDefinition)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // Update indicates an expected call of Update.
-func (mr *MockCustomResourceDefinitionInterfaceMockRecorder) Update(arg0, arg1, arg2 any) *gomock.Call {
+func (mr *MockCustomResourceDefinitionInterfaceMockRecorder) Update(ctx, customResourceDefinition, opts any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Update", reflect.TypeOf((*MockCustomResourceDefinitionInterface)(nil).Update), arg0, arg1, arg2)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Update", reflect.TypeOf((*MockCustomResourceDefinitionInterface)(nil).Update), ctx, customResourceDefinition, opts)
 }
 
 // UpdateStatus mocks base method.
-func (m *MockCustomResourceDefinitionInterface) UpdateStatus(arg0 context.Context, arg1 *v1.CustomResourceDefinition, arg2 v11.UpdateOptions) (*v1.CustomResourceDefinition, error) {
+func (m *MockCustomResourceDefinitionInterface) UpdateStatus(ctx context.Context, customResourceDefinition *v1.CustomResourceDefinition, opts v11.UpdateOptions) (*v1.CustomResourceDefinition, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "UpdateStatus", arg0, arg1, arg2)
+	ret := m.ctrl.Call(m, "UpdateStatus", ctx, customResourceDefinition, opts)
 	ret0, _ := ret[0].(*v1.CustomResourceDefinition)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // UpdateStatus indicates an expected call of UpdateStatus.
-func (mr *MockCustomResourceDefinitionInterfaceMockRecorder) UpdateStatus(arg0, arg1, arg2 any) *gomock.Call {
+func (mr *MockCustomResourceDefinitionInterfaceMockRecorder) UpdateStatus(ctx, customResourceDefinition, opts any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "UpdateStatus", reflect.TypeOf((*MockCustomResourceDefinitionInterface)(nil).UpdateStatus), arg0, arg1, arg2)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "UpdateStatus", reflect.TypeOf((*MockCustomResourceDefinitionInterface)(nil).UpdateStatus), ctx, customResourceDefinition, opts)
 }
 
 // Watch mocks base method.
-func (m *MockCustomResourceDefinitionInterface) Watch(arg0 context.Context, arg1 v11.ListOptions) (watch.Interface, error) {
+func (m *MockCustomResourceDefinitionInterface) Watch(ctx context.Context, opts v11.ListOptions) (watch.Interface, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "Watch", arg0, arg1)
+	ret := m.ctrl.Call(m, "Watch", ctx, opts)
 	ret0, _ := ret[0].(watch.Interface)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // Watch indicates an expected call of Watch.
-func (mr *MockCustomResourceDefinitionInterfaceMockRecorder) Watch(arg0, arg1 any) *gomock.Call {
+func (mr *MockCustomResourceDefinitionInterfaceMockRecorder) Watch(ctx, opts any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Watch", reflect.TypeOf((*MockCustomResourceDefinitionInterface)(nil).Watch), arg0, arg1)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Watch", reflect.TypeOf((*MockCustomResourceDefinitionInterface)(nil).Watch), ctx, opts)
 }

--- a/pkg/generic/clientMocks_test.go
+++ b/pkg/generic/clientMocks_test.go
@@ -26,6 +26,7 @@ import (
 type MockembeddedClient struct {
 	ctrl     *gomock.Controller
 	recorder *MockembeddedClientMockRecorder
+	isgomock struct{}
 }
 
 // MockembeddedClientMockRecorder is the mock recorder for MockembeddedClient.
@@ -71,6 +72,20 @@ func (m *MockembeddedClient) Delete(ctx context.Context, namespace, name string,
 func (mr *MockembeddedClientMockRecorder) Delete(ctx, namespace, name, opts any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Delete", reflect.TypeOf((*MockembeddedClient)(nil).Delete), ctx, namespace, name, opts)
+}
+
+// DeleteCollection mocks base method.
+func (m *MockembeddedClient) DeleteCollection(ctx context.Context, namespace string, opts v1.DeleteOptions, listOpts v1.ListOptions) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "DeleteCollection", ctx, namespace, opts, listOpts)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// DeleteCollection indicates an expected call of DeleteCollection.
+func (mr *MockembeddedClientMockRecorder) DeleteCollection(ctx, namespace, opts, listOpts any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DeleteCollection", reflect.TypeOf((*MockembeddedClient)(nil).DeleteCollection), ctx, namespace, opts, listOpts)
 }
 
 // Get mocks base method.

--- a/pkg/generic/controller.go
+++ b/pkg/generic/controller.go
@@ -116,6 +116,10 @@ type ClientInterface[T RuntimeMetaObject, TList runtime.Object] interface {
 
 	// WithImpersonation returns a new copy of the client that uses impersonation.
 	WithImpersonation(impersonate rest.ImpersonationConfig) (ClientInterface[T, TList], error)
+
+	// DeleteCollection deletes all resources matching the ListOptions in the
+	// provided namespace.
+	DeleteCollection(namespace string, deleteOpts metav1.DeleteOptions, listOpts metav1.ListOptions) error
 }
 
 // NonNamespacedClientInterface is an interface to performs CRUD like operations on nonNamespaced Objects.
@@ -321,6 +325,12 @@ func (c *Controller[T, TList]) Watch(namespace string, opts metav1.ListOptions) 
 func (c *Controller[T, TList]) Patch(namespace, name string, pt types.PatchType, data []byte, subresources ...string) (T, error) {
 	result := reflect.New(c.objType).Interface().(T)
 	return result, c.embeddedClient.Patch(context.TODO(), namespace, name, pt, data, result, metav1.PatchOptions{}, subresources...)
+}
+
+// DeleteCollection will delete the resources in the given namespace matching
+// the listOpts.
+func (c *Controller[T, TList]) DeleteCollection(namespace string, deleteOpts metav1.DeleteOptions, listOpts metav1.ListOptions) error {
+	return c.embeddedClient.DeleteCollection(context.TODO(), namespace, deleteOpts, listOpts)
 }
 
 // WithImpersonation returns a new copy of the client that uses impersonation.

--- a/pkg/generic/controllerFactoryMocks_test.go
+++ b/pkg/generic/controllerFactoryMocks_test.go
@@ -27,6 +27,7 @@ import (
 type MockSharedControllerFactory struct {
 	ctrl     *gomock.Controller
 	recorder *MockSharedControllerFactoryMockRecorder
+	isgomock struct{}
 }
 
 // MockSharedControllerFactoryMockRecorder is the mock recorder for MockSharedControllerFactory.
@@ -47,61 +48,61 @@ func (m *MockSharedControllerFactory) EXPECT() *MockSharedControllerFactoryMockR
 }
 
 // ForKind mocks base method.
-func (m *MockSharedControllerFactory) ForKind(arg0 schema.GroupVersionKind) (controller.SharedController, error) {
+func (m *MockSharedControllerFactory) ForKind(gvk schema.GroupVersionKind) (controller.SharedController, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "ForKind", arg0)
+	ret := m.ctrl.Call(m, "ForKind", gvk)
 	ret0, _ := ret[0].(controller.SharedController)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // ForKind indicates an expected call of ForKind.
-func (mr *MockSharedControllerFactoryMockRecorder) ForKind(arg0 any) *gomock.Call {
+func (mr *MockSharedControllerFactoryMockRecorder) ForKind(gvk any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ForKind", reflect.TypeOf((*MockSharedControllerFactory)(nil).ForKind), arg0)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ForKind", reflect.TypeOf((*MockSharedControllerFactory)(nil).ForKind), gvk)
 }
 
 // ForObject mocks base method.
-func (m *MockSharedControllerFactory) ForObject(arg0 runtime.Object) (controller.SharedController, error) {
+func (m *MockSharedControllerFactory) ForObject(obj runtime.Object) (controller.SharedController, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "ForObject", arg0)
+	ret := m.ctrl.Call(m, "ForObject", obj)
 	ret0, _ := ret[0].(controller.SharedController)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // ForObject indicates an expected call of ForObject.
-func (mr *MockSharedControllerFactoryMockRecorder) ForObject(arg0 any) *gomock.Call {
+func (mr *MockSharedControllerFactoryMockRecorder) ForObject(obj any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ForObject", reflect.TypeOf((*MockSharedControllerFactory)(nil).ForObject), arg0)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ForObject", reflect.TypeOf((*MockSharedControllerFactory)(nil).ForObject), obj)
 }
 
 // ForResource mocks base method.
-func (m *MockSharedControllerFactory) ForResource(arg0 schema.GroupVersionResource, arg1 bool) controller.SharedController {
+func (m *MockSharedControllerFactory) ForResource(gvr schema.GroupVersionResource, namespaced bool) controller.SharedController {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "ForResource", arg0, arg1)
+	ret := m.ctrl.Call(m, "ForResource", gvr, namespaced)
 	ret0, _ := ret[0].(controller.SharedController)
 	return ret0
 }
 
 // ForResource indicates an expected call of ForResource.
-func (mr *MockSharedControllerFactoryMockRecorder) ForResource(arg0, arg1 any) *gomock.Call {
+func (mr *MockSharedControllerFactoryMockRecorder) ForResource(gvr, namespaced any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ForResource", reflect.TypeOf((*MockSharedControllerFactory)(nil).ForResource), arg0, arg1)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ForResource", reflect.TypeOf((*MockSharedControllerFactory)(nil).ForResource), gvr, namespaced)
 }
 
 // ForResourceKind mocks base method.
-func (m *MockSharedControllerFactory) ForResourceKind(arg0 schema.GroupVersionResource, arg1 string, arg2 bool) controller.SharedController {
+func (m *MockSharedControllerFactory) ForResourceKind(gvr schema.GroupVersionResource, kind string, namespaced bool) controller.SharedController {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "ForResourceKind", arg0, arg1, arg2)
+	ret := m.ctrl.Call(m, "ForResourceKind", gvr, kind, namespaced)
 	ret0, _ := ret[0].(controller.SharedController)
 	return ret0
 }
 
 // ForResourceKind indicates an expected call of ForResourceKind.
-func (mr *MockSharedControllerFactoryMockRecorder) ForResourceKind(arg0, arg1, arg2 any) *gomock.Call {
+func (mr *MockSharedControllerFactoryMockRecorder) ForResourceKind(gvr, kind, namespaced any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ForResourceKind", reflect.TypeOf((*MockSharedControllerFactory)(nil).ForResourceKind), arg0, arg1, arg2)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ForResourceKind", reflect.TypeOf((*MockSharedControllerFactory)(nil).ForResourceKind), gvr, kind, namespaced)
 }
 
 // SharedCacheFactory mocks base method.
@@ -119,23 +120,24 @@ func (mr *MockSharedControllerFactoryMockRecorder) SharedCacheFactory() *gomock.
 }
 
 // Start mocks base method.
-func (m *MockSharedControllerFactory) Start(arg0 context.Context, arg1 int) error {
+func (m *MockSharedControllerFactory) Start(ctx context.Context, workers int) error {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "Start", arg0, arg1)
+	ret := m.ctrl.Call(m, "Start", ctx, workers)
 	ret0, _ := ret[0].(error)
 	return ret0
 }
 
 // Start indicates an expected call of Start.
-func (mr *MockSharedControllerFactoryMockRecorder) Start(arg0, arg1 any) *gomock.Call {
+func (mr *MockSharedControllerFactoryMockRecorder) Start(ctx, workers any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Start", reflect.TypeOf((*MockSharedControllerFactory)(nil).Start), arg0, arg1)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Start", reflect.TypeOf((*MockSharedControllerFactory)(nil).Start), ctx, workers)
 }
 
 // MockSharedController is a mock of SharedController interface.
 type MockSharedController struct {
 	ctrl     *gomock.Controller
 	recorder *MockSharedControllerMockRecorder
+	isgomock struct{}
 }
 
 // MockSharedControllerMockRecorder is the mock recorder for MockSharedController.
@@ -170,39 +172,39 @@ func (mr *MockSharedControllerMockRecorder) Client() *gomock.Call {
 }
 
 // Enqueue mocks base method.
-func (m *MockSharedController) Enqueue(arg0, arg1 string) {
+func (m *MockSharedController) Enqueue(namespace, name string) {
 	m.ctrl.T.Helper()
-	m.ctrl.Call(m, "Enqueue", arg0, arg1)
+	m.ctrl.Call(m, "Enqueue", namespace, name)
 }
 
 // Enqueue indicates an expected call of Enqueue.
-func (mr *MockSharedControllerMockRecorder) Enqueue(arg0, arg1 any) *gomock.Call {
+func (mr *MockSharedControllerMockRecorder) Enqueue(namespace, name any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Enqueue", reflect.TypeOf((*MockSharedController)(nil).Enqueue), arg0, arg1)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Enqueue", reflect.TypeOf((*MockSharedController)(nil).Enqueue), namespace, name)
 }
 
 // EnqueueAfter mocks base method.
-func (m *MockSharedController) EnqueueAfter(arg0, arg1 string, arg2 time.Duration) {
+func (m *MockSharedController) EnqueueAfter(namespace, name string, delay time.Duration) {
 	m.ctrl.T.Helper()
-	m.ctrl.Call(m, "EnqueueAfter", arg0, arg1, arg2)
+	m.ctrl.Call(m, "EnqueueAfter", namespace, name, delay)
 }
 
 // EnqueueAfter indicates an expected call of EnqueueAfter.
-func (mr *MockSharedControllerMockRecorder) EnqueueAfter(arg0, arg1, arg2 any) *gomock.Call {
+func (mr *MockSharedControllerMockRecorder) EnqueueAfter(namespace, name, delay any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "EnqueueAfter", reflect.TypeOf((*MockSharedController)(nil).EnqueueAfter), arg0, arg1, arg2)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "EnqueueAfter", reflect.TypeOf((*MockSharedController)(nil).EnqueueAfter), namespace, name, delay)
 }
 
 // EnqueueKey mocks base method.
-func (m *MockSharedController) EnqueueKey(arg0 string) {
+func (m *MockSharedController) EnqueueKey(key string) {
 	m.ctrl.T.Helper()
-	m.ctrl.Call(m, "EnqueueKey", arg0)
+	m.ctrl.Call(m, "EnqueueKey", key)
 }
 
 // EnqueueKey indicates an expected call of EnqueueKey.
-func (mr *MockSharedControllerMockRecorder) EnqueueKey(arg0 any) *gomock.Call {
+func (mr *MockSharedControllerMockRecorder) EnqueueKey(key any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "EnqueueKey", reflect.TypeOf((*MockSharedController)(nil).EnqueueKey), arg0)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "EnqueueKey", reflect.TypeOf((*MockSharedController)(nil).EnqueueKey), key)
 }
 
 // Informer mocks base method.
@@ -220,27 +222,27 @@ func (mr *MockSharedControllerMockRecorder) Informer() *gomock.Call {
 }
 
 // RegisterHandler mocks base method.
-func (m *MockSharedController) RegisterHandler(arg0 context.Context, arg1 string, arg2 controller.SharedControllerHandler) {
+func (m *MockSharedController) RegisterHandler(ctx context.Context, name string, handler controller.SharedControllerHandler) {
 	m.ctrl.T.Helper()
-	m.ctrl.Call(m, "RegisterHandler", arg0, arg1, arg2)
+	m.ctrl.Call(m, "RegisterHandler", ctx, name, handler)
 }
 
 // RegisterHandler indicates an expected call of RegisterHandler.
-func (mr *MockSharedControllerMockRecorder) RegisterHandler(arg0, arg1, arg2 any) *gomock.Call {
+func (mr *MockSharedControllerMockRecorder) RegisterHandler(ctx, name, handler any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "RegisterHandler", reflect.TypeOf((*MockSharedController)(nil).RegisterHandler), arg0, arg1, arg2)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "RegisterHandler", reflect.TypeOf((*MockSharedController)(nil).RegisterHandler), ctx, name, handler)
 }
 
 // Start mocks base method.
-func (m *MockSharedController) Start(arg0 context.Context, arg1 int) error {
+func (m *MockSharedController) Start(ctx context.Context, workers int) error {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "Start", arg0, arg1)
+	ret := m.ctrl.Call(m, "Start", ctx, workers)
 	ret0, _ := ret[0].(error)
 	return ret0
 }
 
 // Start indicates an expected call of Start.
-func (mr *MockSharedControllerMockRecorder) Start(arg0, arg1 any) *gomock.Call {
+func (mr *MockSharedControllerMockRecorder) Start(ctx, workers any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Start", reflect.TypeOf((*MockSharedController)(nil).Start), arg0, arg1)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Start", reflect.TypeOf((*MockSharedController)(nil).Start), ctx, workers)
 }

--- a/pkg/generic/embeddedClient.go
+++ b/pkg/generic/embeddedClient.go
@@ -22,4 +22,5 @@ type embeddedClient interface {
 	UpdateStatus(ctx context.Context, namespace string, obj runtime.Object, result runtime.Object, opts metav1.UpdateOptions) (err error)
 	Watch(ctx context.Context, namespace string, opts metav1.ListOptions) (watch.Interface, error)
 	WithImpersonation(impersonate rest.ImpersonationConfig) (*client.Client, error)
+	DeleteCollection(ctx context.Context, namespace string, opts metav1.DeleteOptions, listOpts metav1.ListOptions) error
 }

--- a/pkg/generic/fake/cache.go
+++ b/pkg/generic/fake/cache.go
@@ -22,6 +22,7 @@ import (
 type MockCacheInterface[T runtime.Object] struct {
 	ctrl     *gomock.Controller
 	recorder *MockCacheInterfaceMockRecorder[T]
+	isgomock struct{}
 }
 
 // MockCacheInterfaceMockRecorder is the mock recorder for MockCacheInterface.
@@ -102,6 +103,7 @@ func (mr *MockCacheInterfaceMockRecorder[T]) List(namespace, selector any) *gomo
 type MockNonNamespacedCacheInterface[T runtime.Object] struct {
 	ctrl     *gomock.Controller
 	recorder *MockNonNamespacedCacheInterfaceMockRecorder[T]
+	isgomock struct{}
 }
 
 // MockNonNamespacedCacheInterfaceMockRecorder is the mock recorder for MockNonNamespacedCacheInterface.

--- a/pkg/generic/fake/controller.go
+++ b/pkg/generic/fake/controller.go
@@ -29,6 +29,7 @@ import (
 type MockControllerMeta struct {
 	ctrl     *gomock.Controller
 	recorder *MockControllerMetaMockRecorder
+	isgomock struct{}
 }
 
 // MockControllerMetaMockRecorder is the mock recorder for MockControllerMeta.
@@ -118,6 +119,7 @@ func (mr *MockControllerMetaMockRecorder) Updater() *gomock.Call {
 type MockRuntimeMetaObject struct {
 	ctrl     *gomock.Controller
 	recorder *MockRuntimeMetaObjectMockRecorder
+	isgomock struct{}
 }
 
 // MockRuntimeMetaObjectMockRecorder is the mock recorder for MockRuntimeMetaObject.
@@ -559,6 +561,7 @@ func (mr *MockRuntimeMetaObjectMockRecorder) SetUID(uid any) *gomock.Call {
 type MockControllerInterface[T generic.RuntimeMetaObject, TList runtime.Object] struct {
 	ctrl     *gomock.Controller
 	recorder *MockControllerInterfaceMockRecorder[T, TList]
+	isgomock struct{}
 }
 
 // MockControllerInterfaceMockRecorder is the mock recorder for MockControllerInterface.
@@ -643,6 +646,20 @@ func (m *MockControllerInterface[T, TList]) Delete(namespace, name string, optio
 func (mr *MockControllerInterfaceMockRecorder[T, TList]) Delete(namespace, name, options any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Delete", reflect.TypeOf((*MockControllerInterface[T, TList])(nil).Delete), namespace, name, options)
+}
+
+// DeleteCollection mocks base method.
+func (m *MockControllerInterface[T, TList]) DeleteCollection(namespace string, deleteOpts v1.DeleteOptions, listOpts v1.ListOptions) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "DeleteCollection", namespace, deleteOpts, listOpts)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// DeleteCollection indicates an expected call of DeleteCollection.
+func (mr *MockControllerInterfaceMockRecorder[T, TList]) DeleteCollection(namespace, deleteOpts, listOpts any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DeleteCollection", reflect.TypeOf((*MockControllerInterface[T, TList])(nil).DeleteCollection), namespace, deleteOpts, listOpts)
 }
 
 // Enqueue mocks base method.
@@ -849,6 +866,7 @@ func (mr *MockControllerInterfaceMockRecorder[T, TList]) WithImpersonation(imper
 type MockNonNamespacedControllerInterface[T generic.RuntimeMetaObject, TList runtime.Object] struct {
 	ctrl     *gomock.Controller
 	recorder *MockNonNamespacedControllerInterfaceMockRecorder[T, TList]
+	isgomock struct{}
 }
 
 // MockNonNamespacedControllerInterfaceMockRecorder is the mock recorder for MockNonNamespacedControllerInterface.
@@ -1139,6 +1157,7 @@ func (mr *MockNonNamespacedControllerInterfaceMockRecorder[T, TList]) WithImpers
 type MockClientInterface[T generic.RuntimeMetaObject, TList runtime.Object] struct {
 	ctrl     *gomock.Controller
 	recorder *MockClientInterfaceMockRecorder[T, TList]
+	isgomock struct{}
 }
 
 // MockClientInterfaceMockRecorder is the mock recorder for MockClientInterface.
@@ -1185,6 +1204,20 @@ func (m *MockClientInterface[T, TList]) Delete(namespace, name string, options *
 func (mr *MockClientInterfaceMockRecorder[T, TList]) Delete(namespace, name, options any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Delete", reflect.TypeOf((*MockClientInterface[T, TList])(nil).Delete), namespace, name, options)
+}
+
+// DeleteCollection mocks base method.
+func (m *MockClientInterface[T, TList]) DeleteCollection(namespace string, deleteOpts v1.DeleteOptions, listOpts v1.ListOptions) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "DeleteCollection", namespace, deleteOpts, listOpts)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// DeleteCollection indicates an expected call of DeleteCollection.
+func (mr *MockClientInterfaceMockRecorder[T, TList]) DeleteCollection(namespace, deleteOpts, listOpts any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DeleteCollection", reflect.TypeOf((*MockClientInterface[T, TList])(nil).DeleteCollection), namespace, deleteOpts, listOpts)
 }
 
 // Get mocks base method.
@@ -1301,6 +1334,7 @@ func (mr *MockClientInterfaceMockRecorder[T, TList]) WithImpersonation(impersona
 type MockNonNamespacedClientInterface[T generic.RuntimeMetaObject, TList runtime.Object] struct {
 	ctrl     *gomock.Controller
 	recorder *MockNonNamespacedClientInterfaceMockRecorder[T, TList]
+	isgomock struct{}
 }
 
 // MockNonNamespacedClientInterfaceMockRecorder is the mock recorder for MockNonNamespacedClientInterface.


### PR DESCRIPTION
This adds support for DeleteCollection which allows for deleting resources using a ListOptions with Selector to select multiple resources in a namespace.

See https://pkg.go.dev/k8s.io/client-go/kubernetes/typed/core/v1#ConfigMapInterface and https://pkg.go.dev/k8s.io/client-go/kubernetes/typed/core/v1#SecretInterface for examples.