### PR TITLE
Update packages to remove dep on archived `github.com/pkg/errors`

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -6,7 +6,6 @@ require (
 	github.com/evanphx/json-patch v5.9.11+incompatible
 	github.com/ghodss/yaml v1.0.0
 	github.com/moby/locker v1.0.1
-	github.com/pkg/errors v0.9.1
 	github.com/rancher/lasso v0.2.7
 	github.com/sirupsen/logrus v1.9.3
 	github.com/stretchr/testify v1.11.1

--- a/go.sum
+++ b/go.sum
@@ -101,8 +101,6 @@ github.com/onsi/ginkgo/v2 v2.27.2 h1:LzwLj0b89qtIy6SSASkzlNvX6WktqurSHwkk2ipF/Ns
 github.com/onsi/ginkgo/v2 v2.27.2/go.mod h1:ArE1D/XhNXBXCBkKOLkbsb2c81dQHCRcF5zwn/ykDRo=
 github.com/onsi/gomega v1.38.2 h1:eZCjf2xjZAqe+LeWvKb5weQ+NcPwX84kqJ0cZNxok2A=
 github.com/onsi/gomega v1.38.2/go.mod h1:W2MJcYxRGV63b418Ai34Ud0hEdTVXq9NW9+Sx6uXf3k=
-github.com/pkg/errors v0.9.1 h1:FEBLx1zS214owpjy7qsBeixbURkuhQAwrK5UwLGTwt4=
-github.com/pkg/errors v0.9.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/pmezard/go-difflib v1.0.1-0.20181226105442-5d4384ee4fb2 h1:Jamvg5psRIccs7FGNTlIRMkT8wgtp5eCXdBlqhYGL6U=
 github.com/pmezard/go-difflib v1.0.1-0.20181226105442-5d4384ee4fb2/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=

--- a/pkg/apply/desiredset_apply.go
+++ b/pkg/apply/desiredset_apply.go
@@ -3,6 +3,7 @@ package apply
 import (
 	"crypto/sha1"
 	"encoding/hex"
+	"errors"
 	"fmt"
 	"sync"
 	"time"
@@ -11,7 +12,6 @@ import (
 
 	gvk2 "github.com/rancher/wrangler/v3/pkg/gvk"
 
-	"github.com/pkg/errors"
 	"github.com/rancher/wrangler/v3/pkg/apply/injectors"
 	"github.com/rancher/wrangler/v3/pkg/objectset"
 	"k8s.io/apimachinery/pkg/api/meta"
@@ -236,7 +236,7 @@ func (o *desiredSet) injectLabelsAndAnnotations(labels, annotations map[string]s
 			obj = obj.DeepCopyObject()
 			meta, err := meta.Accessor(obj)
 			if err != nil {
-				return nil, errors.Wrapf(err, "failed to get metadata for %s", key)
+				return nil, fmt.Errorf("failed to get metadata for %s: %w", key, err)
 			}
 
 			setLabels(meta, labels)

--- a/pkg/apply/desiredset_compare.go
+++ b/pkg/apply/desiredset_compare.go
@@ -4,11 +4,11 @@ import (
 	"bytes"
 	"compress/gzip"
 	"encoding/base64"
+	"fmt"
 	"io/ioutil"
 	"strings"
 
 	jsonpatch "github.com/evanphx/json-patch"
-	"github.com/pkg/errors"
 	data2 "github.com/rancher/wrangler/v3/pkg/data"
 	"github.com/rancher/wrangler/v3/pkg/data/convert"
 	"github.com/rancher/wrangler/v3/pkg/objectset"
@@ -191,7 +191,7 @@ func applyPatch(gvk schema.GroupVersionKind, reconciler Reconciler, patcher Patc
 
 	patchType, patch, err := doPatch(gvk, original, modified, current, diffPatches)
 	if err != nil {
-		return false, errors.Wrap(err, "patch generation")
+		return false, fmt.Errorf("patch generation: %w", err)
 	}
 
 	if string(patch) == "{}" {

--- a/pkg/apply/desiredset_owner.go
+++ b/pkg/apply/desiredset_owner.go
@@ -1,6 +1,7 @@
 package apply
 
 import (
+	"errors"
 	"fmt"
 	"strings"
 
@@ -8,7 +9,6 @@ import (
 
 	"github.com/rancher/wrangler/v3/pkg/kv"
 
-	"github.com/pkg/errors"
 	namer "github.com/rancher/wrangler/v3/pkg/name"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/api/meta"

--- a/pkg/apply/desiredset_process.go
+++ b/pkg/apply/desiredset_process.go
@@ -2,11 +2,11 @@ package apply
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"sort"
 	"sync"
 
-	"github.com/pkg/errors"
 	gvk2 "github.com/rancher/wrangler/v3/pkg/gvk"
 	"github.com/rancher/wrangler/v3/pkg/merr"
 	"github.com/rancher/wrangler/v3/pkg/objectset"
@@ -45,7 +45,7 @@ func (o *desiredSet) getControllerAndClient(debugID string, gvk schema.GroupVers
 	if informer == nil && o.informerFactory != nil {
 		newInformer, err := o.informerFactory.Get(gvk, o.a.clients.gvr(gvk))
 		if err != nil {
-			return nil, nil, errors.Wrapf(err, "failed to construct informer for %v for %s", gvk, debugID)
+			return nil, nil, fmt.Errorf("failed to construct informer for %v for %s: %w", gvk, debugID, err)
 		}
 		informer = newInformer
 	}
@@ -253,7 +253,7 @@ func (o *desiredSet) process(debugID string, set labels.Selector, gvk schema.Gro
 
 	existing, err := o.list(nsed, controller, client, set, objs)
 	if err != nil {
-		o.err(errors.Wrapf(err, "failed to list %s for %s", gvk, debugID))
+		o.err(fmt.Errorf("failed to list %s for %s: %w", gvk, debugID, err))
 		return
 	}
 
@@ -286,7 +286,7 @@ func (o *desiredSet) process(debugID string, set labels.Selector, gvk schema.Gro
 		obj := objs[k]
 		obj, err := prepareObjectForCreate(gvk, obj)
 		if err != nil {
-			o.err(errors.Wrapf(err, "failed to prepare create %s %s for %s", k, gvk, debugID))
+			o.err(fmt.Errorf("failed to prepare create %s %s for %s: %w", k, gvk, debugID, err))
 			return
 		}
 
@@ -301,7 +301,7 @@ func (o *desiredSet) process(debugID string, set labels.Selector, gvk schema.Gro
 			}
 		}
 		if err != nil {
-			o.err(errors.Wrapf(err, "failed to create %s %s for %s", k, gvk, debugID))
+			o.err(fmt.Errorf("failed to create %s %s for %s: %w", k, gvk, debugID, err))
 			return
 		}
 		logrus.Debugf("DesiredSet - Created %s %s for %s", gvk, k, debugID)
@@ -309,7 +309,7 @@ func (o *desiredSet) process(debugID string, set labels.Selector, gvk schema.Gro
 
 	deleteF := func(k objectset.ObjectKey, force bool) {
 		if err := o.delete(nsed, k.Namespace, k.Name, client, force, gvk); err != nil {
-			o.err(errors.Wrapf(err, "failed to delete %s %s for %s", k, gvk, debugID))
+			o.err(fmt.Errorf("failed to delete %s %s for %s: %w", k, gvk, debugID, err))
 			return
 		}
 		logrus.Debugf("DesiredSet - Delete %s %s for %s", gvk, k, debugID)
@@ -321,7 +321,7 @@ func (o *desiredSet) process(debugID string, set labels.Selector, gvk schema.Gro
 			deleteF(k, true)
 			o.err(fmt.Errorf("DesiredSet - Replace Wait %s %s for %s", gvk, k, debugID))
 		} else if err != nil {
-			o.err(errors.Wrapf(err, "failed to update %s %s for %s", k, gvk, debugID))
+			o.err(fmt.Errorf("failed to update %s %s for %s: %w", k, gvk, debugID, err))
 		}
 	}
 

--- a/pkg/gvk/get.go
+++ b/pkg/gvk/get.go
@@ -3,7 +3,6 @@ package gvk
 import (
 	"fmt"
 
-	"github.com/pkg/errors"
 	"github.com/rancher/wrangler/v3/pkg/schemes"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/schema"
@@ -17,7 +16,7 @@ func Get(obj runtime.Object) (schema.GroupVersionKind, error) {
 
 	gvks, _, err := schemes.All.ObjectKinds(obj)
 	if err != nil {
-		return schema.GroupVersionKind{}, errors.Wrapf(err, "failed to find gvk for %T, you may need to import the wrangler generated controller package", obj)
+		return schema.GroupVersionKind{}, fmt.Errorf("failed to find gvk for %T, you may need to import the wrangler generated controller package: %w", obj, err)
 	}
 
 	if len(gvks) == 0 {

--- a/pkg/objectset/objectset.go
+++ b/pkg/objectset/objectset.go
@@ -5,7 +5,6 @@ import (
 	"reflect"
 	"sort"
 
-	"github.com/pkg/errors"
 	"github.com/rancher/wrangler/v3/pkg/gvk"
 	"github.com/rancher/wrangler/v3/pkg/stringset"
 
@@ -113,13 +112,13 @@ func (o *ObjectSet) add(obj runtime.Object) {
 
 	gvk, err := o.objects.Add(obj)
 	if err != nil {
-		o.err(errors.Wrapf(err, "failed to add %T", obj))
+		o.err(fmt.Errorf("failed to add %T: %w", obj, err))
 		return
 	}
 
 	_, err = o.objectsByGK.Add(obj)
 	if err != nil {
-		o.err(errors.Wrapf(err, "failed to add %T", obj))
+		o.err(fmt.Errorf("failed to add %T: %w", obj, err))
 		return
 	}
 

--- a/pkg/resolvehome/main.go
+++ b/pkg/resolvehome/main.go
@@ -1,10 +1,9 @@
 package resolvehome
 
 import (
+	"fmt"
 	"os"
 	"strings"
-
-	"github.com/pkg/errors"
 )
 
 var (
@@ -16,7 +15,7 @@ func Resolve(s string) (string, error) {
 		if strings.Contains(s, home) {
 			homeDir, err := os.UserHomeDir()
 			if err != nil {
-				return "", errors.Wrap(err, "determining current user")
+				return "", fmt.Errorf("determining current user: %w", err)
 			}
 			s = strings.Replace(s, home, homeDir, -1)
 		}

--- a/pkg/yaml/yaml.go
+++ b/pkg/yaml/yaml.go
@@ -5,13 +5,13 @@ import (
 	"bufio"
 	"bytes"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io"
 	"reflect"
 	"strings"
 
 	"github.com/ghodss/yaml"
-	"github.com/pkg/errors"
 	"github.com/rancher/wrangler/v3/pkg/data/convert"
 	"github.com/rancher/wrangler/v3/pkg/gvk"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
@@ -153,7 +153,7 @@ func Export(objects ...runtime.Object) ([]byte, error) {
 
 		bytes, err := yaml.Marshal(obj)
 		if err != nil {
-			return nil, errors.Wrapf(err, "failed to encode %s", obj.GetObjectKind().GroupVersionKind())
+			return nil, fmt.Errorf("failed to encode %s: %w", obj.GetObjectKind().GroupVersionKind(), err)
 		}
 		buffer.Write(bytes)
 	}
@@ -167,7 +167,7 @@ func CleanObjectForExport(obj runtime.Object) (runtime.Object, error) {
 		if gvk, err := gvk.Get(obj); err == nil {
 			obj.GetObjectKind().SetGroupVersionKind(gvk)
 		} else if err != nil {
-			return nil, errors.Wrapf(err, "kind and/or apiVersion is not set on input object: %v", obj)
+			return nil, fmt.Errorf("kind and/or apiVersion is not set on input object: %v: %w", obj, err)
 		}
 	}
 
@@ -267,7 +267,7 @@ func ToBytes(objects []runtime.Object) ([]byte, error) {
 
 		bytes, err := yaml.Marshal(obj)
 		if err != nil {
-			return nil, errors.Wrapf(err, "failed to encode %s", obj.GetObjectKind().GroupVersionKind())
+			return nil, fmt.Errorf("failed to encode %s: %w", obj.GetObjectKind().GroupVersionKind(), err)
 		}
 		buffer.Write(bytes)
 	}


### PR DESCRIPTION
This package has been archived since 2021 and ecosystem is finally moving off it. We should as well.

This removes all direct use of the package. On the master branch, all deps have also moved off it.

errors.Wrap/Wrapf/WithMessage can all be replaced by stdlib fmt.Errorf with %w to wrap the error.

This may also bring some performance increases as Wrap/Wrapf capture a full stack trace from the caller which we do not (to my knowledge) ever actually use.

* Issue: https://github.com/rancher/rancher/issues/54013