### PR TITLE
Support CAPI v1beta2 conditions

### DIFF
--- a/pkg/summary/capi_cluster_test.go
+++ b/pkg/summary/capi_cluster_test.go
@@ -77,7 +77,7 @@ func TestIsCAPICluster(t *testing.T) {
 
 // makeClusterObj builds a minimal CAPI Cluster data.Object with the given
 // worker replica fields under status.workers. Use -1 to omit a field.
-func makeClusterObj(desiredReplicas, replicas, readyReplicas, availableReplicas int64) data.Object {
+func makeClusterObj(desiredReplicas, replicas, readyReplicas, availableReplicas, upToDateReplicas int64) data.Object {
 	obj := data.Object{
 		"apiVersion": "cluster.x-k8s.io/v1beta2",
 		"kind":       "Cluster",
@@ -98,6 +98,9 @@ func makeClusterObj(desiredReplicas, replicas, readyReplicas, availableReplicas 
 	if availableReplicas >= 0 {
 		workers["availableReplicas"] = availableReplicas
 	}
+	if upToDateReplicas >= 0 {
+		workers["upToDateReplicas"] = upToDateReplicas
+	}
 	return obj
 }
 
@@ -114,7 +117,7 @@ func TestCheckCAPIClusterTransitioning(t *testing.T) {
 		// --- Priority 1: Deleting ---
 		{
 			name: "Deleting=True takes absolute priority over everything",
-			obj:  makeClusterObj(1, 1, 1, 1),
+			obj:  makeClusterObj(1, 1, 1, 1, -1),
 			conditions: []Condition{
 				NewCondition("Available", "False", "NotAvailable", "* Deleting: ..."),
 				NewCondition("ScalingDown", "True", "ScalingDown", "* MachineDeployment md: Scaling down from 1 to 0 replicas"),
@@ -128,7 +131,7 @@ func TestCheckCAPIClusterTransitioning(t *testing.T) {
 		},
 		{
 			name: "Deleting=True with empty message",
-			obj:  makeClusterObj(1, 1, 1, 1),
+			obj:  makeClusterObj(1, 1, 1, 1, -1),
 			conditions: []Condition{
 				NewCondition("Deleting", "True", "Deleting", ""),
 			},
@@ -139,7 +142,7 @@ func TestCheckCAPIClusterTransitioning(t *testing.T) {
 		},
 		{
 			name: "Deleting=False does not trigger removing",
-			obj:  makeClusterObj(2, 2, 2, 2),
+			obj:  makeClusterObj(2, 2, 2, 2, -1),
 			conditions: []Condition{
 				NewCondition("Available", "True", "Available", ""),
 				NewCondition("Deleting", "False", "NotDeleting", ""),
@@ -155,7 +158,7 @@ func TestCheckCAPIClusterTransitioning(t *testing.T) {
 		// --- Priority 2: Paused ---
 		{
 			name: "Paused=True takes priority over scaling and Available",
-			obj:  makeClusterObj(3, 2, 2, 2),
+			obj:  makeClusterObj(3, 2, 2, 2, -1),
 			conditions: []Condition{
 				NewCondition("Available", "False", "NotAvailable", "something"),
 				NewCondition("ScalingUp", "True", "ScalingUp", "scaling"),
@@ -168,7 +171,7 @@ func TestCheckCAPIClusterTransitioning(t *testing.T) {
 		},
 		{
 			name: "Paused=False is ignored",
-			obj:  makeClusterObj(2, 2, 2, 2),
+			obj:  makeClusterObj(2, 2, 2, 2, -1),
 			conditions: []Condition{
 				NewCondition("Available", "True", "Available", ""),
 				NewCondition("Paused", "False", "NotPaused", ""),
@@ -181,10 +184,44 @@ func TestCheckCAPIClusterTransitioning(t *testing.T) {
 			expectedError:   false,
 		},
 
-		// --- Priority 3: ScalingDown ---
+		// --- Priority 3: Rolling out ---
+		{
+			name: "RollingOut=True takes priority over ScalingDown during rolling upgrade",
+			obj:  makeClusterObj(4, 5, 5, 5, 3),
+			conditions: []Condition{
+				NewCondition("Deleting", "False", "NotDeleting", ""),
+				NewCondition("Paused", "False", "NotPaused", ""),
+				NewCondition("RollingOut", "True", "RollingOut", "* MachineDeployment do-check-jiaqi-dow:\n  * Rolling out 2 not up-to-date replicas"),
+				NewCondition("ScalingDown", "True", "ScalingDown", "* MachineDeployment do-check-jiaqi-dow: Scaling down from 4 to 3 replicas"),
+				NewCondition("ScalingUp", "False", "NotScalingUp", ""),
+				NewCondition("Available", "True", "Available", ""),
+			},
+			expectedState:    "rollingout",
+			expectedTransit:  true,
+			expectedError:    false,
+			expectedMessages: []string{"rolling out 2 not up-to-date replicas"},
+		},
+		{
+			name: "RollingOut=True takes priority over ScalingUp during rolling upgrade",
+			obj:  makeClusterObj(4, 4, 3, 3, 2),
+			conditions: []Condition{
+				NewCondition("Deleting", "False", "NotDeleting", ""),
+				NewCondition("Paused", "False", "NotPaused", ""),
+				NewCondition("RollingOut", "True", "RollingOut", "* MachineDeployment md:\n  * Rolling out 2 not up-to-date replicas"),
+				NewCondition("ScalingDown", "False", "NotScalingDown", ""),
+				NewCondition("ScalingUp", "False", "NotScalingUp", ""),
+				NewCondition("Available", "False", "NotAvailable", "something"),
+			},
+			expectedState:    "rollingout",
+			expectedTransit:  true,
+			expectedError:    false,
+			expectedMessages: []string{"rolling out 2 not up-to-date replicas"},
+		},
+
+		// --- Priority 4: ScalingDown ---
 		{
 			name: "ScalingDown=True — message constructed from worker replicas",
-			obj:  makeClusterObj(2, 3, 3, 3),
+			obj:  makeClusterObj(2, 3, 3, 3, -1),
 			conditions: []Condition{
 				NewCondition("Available", "True", "Available", ""),
 				NewCondition("ScalingDown", "True", "ScalingDown", "* MachineDeployment md: Scaling down from 2 to 1 replicas"),
@@ -199,7 +236,7 @@ func TestCheckCAPIClusterTransitioning(t *testing.T) {
 		},
 		{
 			name: "ScalingDown detected by replica mismatch only (stale condition)",
-			obj:  makeClusterObj(2, 3, 2, 2),
+			obj:  makeClusterObj(2, 3, 2, 2, -1),
 			conditions: []Condition{
 				NewCondition("Available", "True", "Available", ""),
 				NewCondition("ScalingDown", "False", "NotScalingDown", ""),
@@ -214,7 +251,7 @@ func TestCheckCAPIClusterTransitioning(t *testing.T) {
 		},
 		{
 			name: "ScalingDown takes priority over ScalingUp when both detectable",
-			obj:  makeClusterObj(1, 3, 0, 0),
+			obj:  makeClusterObj(1, 3, 0, 0, -1),
 			conditions: []Condition{
 				NewCondition("ScalingDown", "True", "ScalingDown", "scaling down"),
 				NewCondition("ScalingUp", "False", "NotScalingUp", ""),
@@ -227,10 +264,10 @@ func TestCheckCAPIClusterTransitioning(t *testing.T) {
 			expectedMessages: []string{"Scaling down from 3 to 1 machines"},
 		},
 
-		// --- Priority 4: ScalingUp ---
+		// --- Priority 5: ScalingUp ---
 		{
 			name: "ScalingUp=True — scale-up scenario (2→3 workers)",
-			obj:  makeClusterObj(3, 2, 2, 2),
+			obj:  makeClusterObj(3, 2, 2, 2, -1),
 			conditions: []Condition{
 				NewCondition("Available", "False", "NotAvailable", "* WorkersAvailable: insufficient replicas"),
 				NewCondition("ScalingUp", "True", "ScalingUp", "* MachineDeployment md: Scaling up from 1 to 2 replicas"),
@@ -244,8 +281,8 @@ func TestCheckCAPIClusterTransitioning(t *testing.T) {
 			expectedMessages: []string{"Scaling up from 2 to 3 machines"},
 		},
 		{
-			name: "ScalingUp detected by readyReplicas mismatch only (stale condition)",
-			obj:  makeClusterObj(3, 2, 2, 2),
+			name: "ScalingUp detected by replica mismatch (stale condition)",
+			obj:  makeClusterObj(3, 2, 2, 2, -1),
 			conditions: []Condition{
 				NewCondition("Available", "False", "NotAvailable", "something"),
 				NewCondition("ScalingUp", "False", "NotScalingUp", ""),
@@ -260,7 +297,7 @@ func TestCheckCAPIClusterTransitioning(t *testing.T) {
 		},
 		{
 			name: "ScalingUp during cluster creation (0→1 workers)",
-			obj:  makeClusterObj(1, -1, -1, -1),
+			obj:  makeClusterObj(1, -1, -1, -1, -1),
 			conditions: []Condition{
 				NewCondition("Available", "False", "NotAvailable", "* WorkersAvailable: waiting"),
 				NewCondition("ScalingUp", "True", "ScalingUp", "* MachineDeployment md: Scaling up from 0 to 1 replicas"),
@@ -277,7 +314,7 @@ func TestCheckCAPIClusterTransitioning(t *testing.T) {
 		},
 		{
 			name: "ScalingUp from zero readyReplicas during creation",
-			obj:  makeClusterObj(1, 0, 0, 0),
+			obj:  makeClusterObj(1, 0, 0, 0, -1),
 			conditions: []Condition{
 				NewCondition("Available", "False", "NotAvailable", "not available"),
 				NewCondition("ScalingUp", "True", "ScalingUp", "* MachineDeployment md: Scaling up from 0 to 1 replicas"),
@@ -290,11 +327,27 @@ func TestCheckCAPIClusterTransitioning(t *testing.T) {
 			expectedError:    false,
 			expectedMessages: []string{"Scaling up from 0 to 1 machines"},
 		},
+		{
+			name: "Desired workers exceed ready workers — reports scalingup before Available=False",
+			obj:  makeClusterObj(3, 3, 2, 2, 3),
+			conditions: []Condition{
+				NewCondition("Available", "False", "NotAvailable", "* MachineDeployment md: 2 available, 3 required"),
+				NewCondition("ScalingUp", "False", "NotScalingUp", ""),
+				NewCondition("ScalingDown", "False", "NotScalingDown", ""),
+				NewCondition("RollingOut", "False", "NotRollingOut", ""),
+				NewCondition("Deleting", "False", "NotDeleting", ""),
+				NewCondition("Paused", "False", "NotPaused", ""),
+			},
+			expectedState:    "updating",
+			expectedTransit:  true,
+			expectedError:    false,
+			expectedMessages: []string{"Scaling up from 2 to 3 machines"},
+		},
 
-		// --- Priority 5: Available=False ---
+		// --- Priority 6: Available=False ---
 		{
 			name: "Available=False without any scaling → updating",
-			obj:  makeClusterObj(2, 2, 2, 2),
+			obj:  makeClusterObj(2, 2, 2, 2, -1),
 			conditions: []Condition{
 				NewCondition("Available", "False", "NotAvailable", "* RemoteConnectionProbe: Remote connection not established yet"),
 				NewCondition("ScalingUp", "False", "NotScalingUp", ""),
@@ -309,7 +362,7 @@ func TestCheckCAPIClusterTransitioning(t *testing.T) {
 		},
 		{
 			name: "Available=False with empty message → updating with no messages",
-			obj:  makeClusterObj(1, 1, 1, 1),
+			obj:  makeClusterObj(1, 1, 1, 1, -1),
 			conditions: []Condition{
 				NewCondition("Available", "False", "NotAvailable", ""),
 				NewCondition("ScalingUp", "False", "NotScalingUp", ""),
@@ -321,11 +374,66 @@ func TestCheckCAPIClusterTransitioning(t *testing.T) {
 			expectedTransit: true,
 			expectedError:   false,
 		},
+		{
+			name: "Deleting=True takes priority over RollingOut=True on Cluster",
+			obj:  makeClusterObj(4, 5, 5, 5, 3),
+			conditions: []Condition{
+				NewCondition("Deleting", "True", "WaitingForWorkersDeletion", "cleanup"),
+				NewCondition("RollingOut", "True", "RollingOut", "* MachineDeployment md:\n  * Rolling out 2 not up-to-date replicas"),
+				NewCondition("ScalingDown", "True", "ScalingDown", "scaling down"),
+			},
+			expectedState:    "deleting",
+			expectedTransit:  true,
+			expectedError:    false,
+			expectedMessages: []string{"cleanup"},
+		},
+		{
+			name: "Paused=True takes priority over RollingOut=True on Cluster",
+			obj:  makeClusterObj(4, 5, 5, 5, 3),
+			conditions: []Condition{
+				NewCondition("Deleting", "False", "NotDeleting", ""),
+				NewCondition("Paused", "True", "Paused", ""),
+				NewCondition("RollingOut", "True", "RollingOut", "* MachineDeployment md:\n  * Rolling out 2 not up-to-date replicas"),
+			},
+			expectedState:   "paused",
+			expectedTransit: true,
+			expectedError:   false,
+		},
+		{
+			name: "RollingOut=False does not trigger rollingout — falls through to ScalingDown",
+			obj:  makeClusterObj(3, 4, 4, 4, -1),
+			conditions: []Condition{
+				NewCondition("Deleting", "False", "NotDeleting", ""),
+				NewCondition("Paused", "False", "NotPaused", ""),
+				NewCondition("RollingOut", "False", "NotRollingOut", ""),
+				NewCondition("ScalingDown", "True", "ScalingDown", "scaling down"),
+				NewCondition("ScalingUp", "False", "NotScalingUp", ""),
+				NewCondition("Available", "True", "Available", ""),
+			},
+			expectedState:    "updating",
+			expectedTransit:  true,
+			expectedError:    false,
+			expectedMessages: []string{"Scaling down from 4 to 3 machines"},
+		},
+		{
+			name: "RollingOut=True on Cluster with missing upToDateReplicas — no message",
+			obj:  makeClusterObj(4, 5, 5, 5, -1),
+			conditions: []Condition{
+				NewCondition("Deleting", "False", "NotDeleting", ""),
+				NewCondition("Paused", "False", "NotPaused", ""),
+				NewCondition("RollingOut", "True", "RollingOut", "* MachineDeployment md:\n  * Rolling out 2 not up-to-date replicas"),
+				NewCondition("ScalingDown", "True", "ScalingDown", "scaling down"),
+			},
+			expectedState:    "rollingout",
+			expectedTransit:  true,
+			expectedError:    false,
+			expectedMessages: nil,
+		},
 
-		// --- Priority 6: Steady state / pass through ---
+		// --- Priority 7: Steady state / pass through ---
 		{
 			name: "Steady state — all healthy → pass through",
-			obj:  makeClusterObj(2, 2, 2, 2),
+			obj:  makeClusterObj(2, 2, 2, 2, -1),
 			conditions: []Condition{
 				NewCondition("Available", "True", "Available", ""),
 				NewCondition("ScalingUp", "False", "NotScalingUp", ""),
@@ -345,7 +453,7 @@ func TestCheckCAPIClusterTransitioning(t *testing.T) {
 		// --- Edge cases ---
 		{
 			name:            "No conditions → pass through",
-			obj:             makeClusterObj(1, 1, 1, 1),
+			obj:             makeClusterObj(1, 1, 1, 1, -1),
 			conditions:      []Condition{},
 			expectedState:   "",
 			expectedTransit: false,
@@ -404,7 +512,7 @@ func TestCheckCAPIClusterTransitioning(t *testing.T) {
 		},
 		{
 			name: "Deleting=True takes priority over active scale-down",
-			obj:  makeClusterObj(1, 1, 1, 1),
+			obj:  makeClusterObj(1, 1, 1, 1, -1),
 			conditions: []Condition{
 				NewCondition("Deleting", "True", "WaitingForWorkersDeletion", "cleanup in progress"),
 				NewCondition("Paused", "False", "NotPaused", ""),
@@ -418,7 +526,7 @@ func TestCheckCAPIClusterTransitioning(t *testing.T) {
 		},
 		{
 			name: "Paused=True takes priority over scale-up detected by replicas",
-			obj:  makeClusterObj(3, 1, 1, 1),
+			obj:  makeClusterObj(3, 1, 1, 1, -1),
 			conditions: []Condition{
 				NewCondition("Deleting", "False", "NotDeleting", ""),
 				NewCondition("Paused", "True", "Paused", ""),
@@ -452,7 +560,7 @@ func TestCheckCAPIClusterTransitioning(t *testing.T) {
 func TestCheckTransitioning_CAPIClusterDispatch(t *testing.T) {
 	// A CAPI Cluster with ScalingUp=True should get "updating" from the
 	// CAPI Cluster path.
-	capiObj := makeClusterObj(2, 1, 1, 1)
+	capiObj := makeClusterObj(2, 1, 1, 1, -1)
 	conditions := []Condition{
 		NewCondition("ScalingUp", "True", "ScalingUp", "* MachineDeployment md: Scaling up from 1 to 2 replicas"),
 		NewCondition("ScalingDown", "False", "NotScalingDown", ""),
@@ -463,6 +571,22 @@ func TestCheckTransitioning_CAPIClusterDispatch(t *testing.T) {
 	result := checkTransitioning(capiObj, conditions, Summary{})
 	assert.Equal(t, "updating", result.State)
 	assert.True(t, result.Transitioning)
+
+	// A CAPI Cluster with RollingOut=True during a rolling upgrade should
+	// get state="rollingout" instead of "updating" (from ScalingDown).
+	rollingClusterObj := makeClusterObj(4, 5, 5, 5, 3)
+	rollingConditions := []Condition{
+		NewCondition("Deleting", "False", "NotDeleting", ""),
+		NewCondition("Paused", "False", "NotPaused", ""),
+		NewCondition("RollingOut", "True", "RollingOut", "* MachineDeployment md:\n  * Rolling out 2 not up-to-date replicas"),
+		NewCondition("ScalingDown", "True", "ScalingDown", "* MachineDeployment md: Scaling down from 4 to 3 replicas"),
+		NewCondition("ScalingUp", "False", "NotScalingUp", ""),
+		NewCondition("Available", "True", "Available", ""),
+	}
+	rollingResult := checkTransitioning(rollingClusterObj, rollingConditions, Summary{})
+	assert.Equal(t, "rollingout", rollingResult.State, "rolling upgrade should produce state=rollingout")
+	assert.True(t, rollingResult.Transitioning)
+	assert.Equal(t, []string{"rolling out 2 not up-to-date replicas"}, rollingResult.Message)
 
 	// A non-CAPI Cluster (e.g. management.cattle.io) should use the generic path.
 	genericObj := data.Object{

--- a/pkg/summary/capi_cluster_test.go
+++ b/pkg/summary/capi_cluster_test.go
@@ -1,0 +1,478 @@
+package summary
+
+import (
+	"testing"
+
+	"github.com/rancher/wrangler/v3/pkg/data"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestIsCAPICluster(t *testing.T) {
+	tests := []struct {
+		name     string
+		obj      data.Object
+		expected bool
+	}{
+		{
+			name: "CAPI v1beta2 Cluster",
+			obj: data.Object{
+				"apiVersion": "cluster.x-k8s.io/v1beta2",
+				"kind":       "Cluster",
+			},
+			expected: true,
+		},
+		{
+			name: "CAPI v1beta1 Cluster",
+			obj: data.Object{
+				"apiVersion": "cluster.x-k8s.io/v1beta1",
+				"kind":       "Cluster",
+			},
+			expected: true,
+		},
+		{
+			name: "CAPI v1beta2 Machine (not Cluster)",
+			obj: data.Object{
+				"apiVersion": "cluster.x-k8s.io/v1beta2",
+				"kind":       "Machine",
+			},
+			expected: false,
+		},
+		{
+			name: "CAPI v1beta2 MachineSet (not Cluster)",
+			obj: data.Object{
+				"apiVersion": "cluster.x-k8s.io/v1beta2",
+				"kind":       "MachineSet",
+			},
+			expected: false,
+		},
+		{
+			name: "Rancher management Cluster (not CAPI)",
+			obj: data.Object{
+				"apiVersion": "management.cattle.io/v3",
+				"kind":       "Cluster",
+			},
+			expected: false,
+		},
+		{
+			name: "non-CAPI kind",
+			obj: data.Object{
+				"apiVersion": "apps/v1",
+				"kind":       "Deployment",
+			},
+			expected: false,
+		},
+		{
+			name:     "empty object",
+			obj:      data.Object{},
+			expected: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.expected, isCAPICluster(tt.obj))
+		})
+	}
+}
+
+// makeClusterObj builds a minimal CAPI Cluster data.Object with the given
+// worker replica fields under status.workers. Use -1 to omit a field.
+func makeClusterObj(desiredReplicas, replicas, readyReplicas, availableReplicas int64) data.Object {
+	obj := data.Object{
+		"apiVersion": "cluster.x-k8s.io/v1beta2",
+		"kind":       "Cluster",
+		"status": map[string]interface{}{
+			"workers": map[string]interface{}{},
+		},
+	}
+	workers := obj["status"].(map[string]interface{})["workers"].(map[string]interface{})
+	if desiredReplicas >= 0 {
+		workers["desiredReplicas"] = desiredReplicas
+	}
+	if replicas >= 0 {
+		workers["replicas"] = replicas
+	}
+	if readyReplicas >= 0 {
+		workers["readyReplicas"] = readyReplicas
+	}
+	if availableReplicas >= 0 {
+		workers["availableReplicas"] = availableReplicas
+	}
+	return obj
+}
+
+func TestCheckCAPIClusterTransitioning(t *testing.T) {
+	tests := []struct {
+		name             string
+		obj              data.Object
+		conditions       []Condition
+		expectedState    string
+		expectedTransit  bool
+		expectedError    bool
+		expectedMessages []string
+	}{
+		// --- Priority 1: Deleting ---
+		{
+			name: "Deleting=True takes absolute priority over everything",
+			obj:  makeClusterObj(1, 1, 1, 1),
+			conditions: []Condition{
+				NewCondition("Available", "False", "NotAvailable", "* Deleting: ..."),
+				NewCondition("ScalingDown", "True", "ScalingDown", "* MachineDeployment md: Scaling down from 1 to 0 replicas"),
+				NewCondition("Deleting", "True", "WaitingForWorkersDeletion", "* MachineDeployments: md\n* MachineSets: ms"),
+				NewCondition("Paused", "False", "NotPaused", ""),
+			},
+			expectedState:    "deleting",
+			expectedTransit:  true,
+			expectedError:    false,
+			expectedMessages: []string{"waiting for workers deletion"},
+		},
+		{
+			name: "Deleting=True with empty message",
+			obj:  makeClusterObj(1, 1, 1, 1),
+			conditions: []Condition{
+				NewCondition("Deleting", "True", "Deleting", ""),
+			},
+			expectedState:    "deleting",
+			expectedTransit:  true,
+			expectedError:    false,
+			expectedMessages: nil,
+		},
+		{
+			name: "Deleting=False does not trigger removing",
+			obj:  makeClusterObj(2, 2, 2, 2),
+			conditions: []Condition{
+				NewCondition("Available", "True", "Available", ""),
+				NewCondition("Deleting", "False", "NotDeleting", ""),
+				NewCondition("Paused", "False", "NotPaused", ""),
+				NewCondition("ScalingUp", "False", "NotScalingUp", ""),
+				NewCondition("ScalingDown", "False", "NotScalingDown", ""),
+			},
+			expectedState:   "",
+			expectedTransit: false,
+			expectedError:   false,
+		},
+
+		// --- Priority 2: Paused ---
+		{
+			name: "Paused=True takes priority over scaling and Available",
+			obj:  makeClusterObj(3, 2, 2, 2),
+			conditions: []Condition{
+				NewCondition("Available", "False", "NotAvailable", "something"),
+				NewCondition("ScalingUp", "True", "ScalingUp", "scaling"),
+				NewCondition("Paused", "True", "Paused", "cluster is paused"),
+				NewCondition("Deleting", "False", "NotDeleting", ""),
+			},
+			expectedState:   "paused",
+			expectedTransit: true,
+			expectedError:   false,
+		},
+		{
+			name: "Paused=False is ignored",
+			obj:  makeClusterObj(2, 2, 2, 2),
+			conditions: []Condition{
+				NewCondition("Available", "True", "Available", ""),
+				NewCondition("Paused", "False", "NotPaused", ""),
+				NewCondition("Deleting", "False", "NotDeleting", ""),
+				NewCondition("ScalingUp", "False", "NotScalingUp", ""),
+				NewCondition("ScalingDown", "False", "NotScalingDown", ""),
+			},
+			expectedState:   "",
+			expectedTransit: false,
+			expectedError:   false,
+		},
+
+		// --- Priority 3: ScalingDown ---
+		{
+			name: "ScalingDown=True — message constructed from worker replicas",
+			obj:  makeClusterObj(2, 3, 3, 3),
+			conditions: []Condition{
+				NewCondition("Available", "True", "Available", ""),
+				NewCondition("ScalingDown", "True", "ScalingDown", "* MachineDeployment md: Scaling down from 2 to 1 replicas"),
+				NewCondition("ScalingUp", "False", "NotScalingUp", ""),
+				NewCondition("Deleting", "False", "NotDeleting", ""),
+				NewCondition("Paused", "False", "NotPaused", ""),
+			},
+			expectedState:    "updating",
+			expectedTransit:  true,
+			expectedError:    false,
+			expectedMessages: []string{"Scaling down from 3 to 2 machines"},
+		},
+		{
+			name: "ScalingDown detected by replica mismatch only (stale condition)",
+			obj:  makeClusterObj(2, 3, 2, 2),
+			conditions: []Condition{
+				NewCondition("Available", "True", "Available", ""),
+				NewCondition("ScalingDown", "False", "NotScalingDown", ""),
+				NewCondition("ScalingUp", "False", "NotScalingUp", ""),
+				NewCondition("Deleting", "False", "NotDeleting", ""),
+				NewCondition("Paused", "False", "NotPaused", ""),
+			},
+			expectedState:    "updating",
+			expectedTransit:  true,
+			expectedError:    false,
+			expectedMessages: []string{"Scaling down from 3 to 2 machines"},
+		},
+		{
+			name: "ScalingDown takes priority over ScalingUp when both detectable",
+			obj:  makeClusterObj(1, 3, 0, 0),
+			conditions: []Condition{
+				NewCondition("ScalingDown", "True", "ScalingDown", "scaling down"),
+				NewCondition("ScalingUp", "False", "NotScalingUp", ""),
+				NewCondition("Deleting", "False", "NotDeleting", ""),
+				NewCondition("Paused", "False", "NotPaused", ""),
+			},
+			expectedState:    "updating",
+			expectedTransit:  true,
+			expectedError:    false,
+			expectedMessages: []string{"Scaling down from 3 to 1 machines"},
+		},
+
+		// --- Priority 4: ScalingUp ---
+		{
+			name: "ScalingUp=True — scale-up scenario (2→3 workers)",
+			obj:  makeClusterObj(3, 2, 2, 2),
+			conditions: []Condition{
+				NewCondition("Available", "False", "NotAvailable", "* WorkersAvailable: insufficient replicas"),
+				NewCondition("ScalingUp", "True", "ScalingUp", "* MachineDeployment md: Scaling up from 1 to 2 replicas"),
+				NewCondition("ScalingDown", "False", "NotScalingDown", ""),
+				NewCondition("Deleting", "False", "NotDeleting", ""),
+				NewCondition("Paused", "False", "NotPaused", ""),
+			},
+			expectedState:    "updating",
+			expectedTransit:  true,
+			expectedError:    false,
+			expectedMessages: []string{"Scaling up from 2 to 3 machines"},
+		},
+		{
+			name: "ScalingUp detected by readyReplicas mismatch only (stale condition)",
+			obj:  makeClusterObj(3, 2, 2, 2),
+			conditions: []Condition{
+				NewCondition("Available", "False", "NotAvailable", "something"),
+				NewCondition("ScalingUp", "False", "NotScalingUp", ""),
+				NewCondition("ScalingDown", "False", "NotScalingDown", ""),
+				NewCondition("Deleting", "False", "NotDeleting", ""),
+				NewCondition("Paused", "False", "NotPaused", ""),
+			},
+			expectedState:    "updating",
+			expectedTransit:  true,
+			expectedError:    false,
+			expectedMessages: []string{"Scaling up from 2 to 3 machines"},
+		},
+		{
+			name: "ScalingUp during cluster creation (0→1 workers)",
+			obj:  makeClusterObj(1, -1, -1, -1),
+			conditions: []Condition{
+				NewCondition("Available", "False", "NotAvailable", "* WorkersAvailable: waiting"),
+				NewCondition("ScalingUp", "True", "ScalingUp", "* MachineDeployment md: Scaling up from 0 to 1 replicas"),
+				NewCondition("ControlPlaneInitialized", "False", "NotInitialized", "Control plane not yet initialized"),
+				NewCondition("ControlPlaneAvailable", "False", "NotAvailable", "CP not available"),
+				NewCondition("Deleting", "False", "NotDeleting", ""),
+				NewCondition("Paused", "False", "NotPaused", ""),
+				NewCondition("ScalingDown", "False", "NotScalingDown", ""),
+			},
+			expectedState:    "updating",
+			expectedTransit:  true,
+			expectedError:    false,
+			expectedMessages: nil, // no readyReplicas field → no message
+		},
+		{
+			name: "ScalingUp from zero readyReplicas during creation",
+			obj:  makeClusterObj(1, 0, 0, 0),
+			conditions: []Condition{
+				NewCondition("Available", "False", "NotAvailable", "not available"),
+				NewCondition("ScalingUp", "True", "ScalingUp", "* MachineDeployment md: Scaling up from 0 to 1 replicas"),
+				NewCondition("ScalingDown", "False", "NotScalingDown", ""),
+				NewCondition("Deleting", "False", "NotDeleting", ""),
+				NewCondition("Paused", "False", "NotPaused", ""),
+			},
+			expectedState:    "updating",
+			expectedTransit:  true,
+			expectedError:    false,
+			expectedMessages: []string{"Scaling up from 0 to 1 machines"},
+		},
+
+		// --- Priority 5: Available=False ---
+		{
+			name: "Available=False without any scaling → updating",
+			obj:  makeClusterObj(2, 2, 2, 2),
+			conditions: []Condition{
+				NewCondition("Available", "False", "NotAvailable", "* RemoteConnectionProbe: Remote connection not established yet"),
+				NewCondition("ScalingUp", "False", "NotScalingUp", ""),
+				NewCondition("ScalingDown", "False", "NotScalingDown", ""),
+				NewCondition("Deleting", "False", "NotDeleting", ""),
+				NewCondition("Paused", "False", "NotPaused", ""),
+			},
+			expectedState:    "updating",
+			expectedTransit:  true,
+			expectedError:    false,
+			expectedMessages: []string{"establishing connection to control plane"},
+		},
+		{
+			name: "Available=False with empty message → updating with no messages",
+			obj:  makeClusterObj(1, 1, 1, 1),
+			conditions: []Condition{
+				NewCondition("Available", "False", "NotAvailable", ""),
+				NewCondition("ScalingUp", "False", "NotScalingUp", ""),
+				NewCondition("ScalingDown", "False", "NotScalingDown", ""),
+				NewCondition("Deleting", "False", "NotDeleting", ""),
+				NewCondition("Paused", "False", "NotPaused", ""),
+			},
+			expectedState:   "updating",
+			expectedTransit: true,
+			expectedError:   false,
+		},
+
+		// --- Priority 6: Steady state / pass through ---
+		{
+			name: "Steady state — all healthy → pass through",
+			obj:  makeClusterObj(2, 2, 2, 2),
+			conditions: []Condition{
+				NewCondition("Available", "True", "Available", ""),
+				NewCondition("ScalingUp", "False", "NotScalingUp", ""),
+				NewCondition("ScalingDown", "False", "NotScalingDown", ""),
+				NewCondition("Deleting", "False", "NotDeleting", ""),
+				NewCondition("Paused", "False", "NotPaused", ""),
+				NewCondition("WorkersAvailable", "True", "Available", ""),
+				NewCondition("ControlPlaneAvailable", "True", "Available", ""),
+				NewCondition("WorkerMachinesReady", "True", "Ready", ""),
+				NewCondition("ControlPlaneMachinesReady", "True", "Ready", ""),
+			},
+			expectedState:   "",
+			expectedTransit: false,
+			expectedError:   false,
+		},
+
+		// --- Edge cases ---
+		{
+			name:            "No conditions → pass through",
+			obj:             makeClusterObj(1, 1, 1, 1),
+			conditions:      []Condition{},
+			expectedState:   "",
+			expectedTransit: false,
+			expectedError:   false,
+		},
+		{
+			name: "Missing worker replica fields → pass through (no panic)",
+			obj: data.Object{
+				"apiVersion": "cluster.x-k8s.io/v1beta2",
+				"kind":       "Cluster",
+			},
+			conditions: []Condition{
+				NewCondition("Available", "True", "Available", ""),
+				NewCondition("Deleting", "False", "NotDeleting", ""),
+				NewCondition("Paused", "False", "NotPaused", ""),
+				NewCondition("ScalingDown", "False", "NotScalingDown", ""),
+				NewCondition("ScalingUp", "False", "NotScalingUp", ""),
+			},
+			expectedState:   "",
+			expectedTransit: false,
+			expectedError:   false,
+		},
+		{
+			name: "ScalingUp=True but no worker replica fields → updating, no message",
+			obj: data.Object{
+				"apiVersion": "cluster.x-k8s.io/v1beta2",
+				"kind":       "Cluster",
+			},
+			conditions: []Condition{
+				NewCondition("Deleting", "False", "NotDeleting", ""),
+				NewCondition("Paused", "False", "NotPaused", ""),
+				NewCondition("ScalingDown", "False", "NotScalingDown", ""),
+				NewCondition("ScalingUp", "True", "ScalingUp", "Scaling up"),
+			},
+			expectedState:    "updating",
+			expectedTransit:  true,
+			expectedError:    false,
+			expectedMessages: nil,
+		},
+		{
+			name: "ScalingDown=True but no worker replica fields → updating, no message",
+			obj: data.Object{
+				"apiVersion": "cluster.x-k8s.io/v1beta2",
+				"kind":       "Cluster",
+			},
+			conditions: []Condition{
+				NewCondition("Deleting", "False", "NotDeleting", ""),
+				NewCondition("Paused", "False", "NotPaused", ""),
+				NewCondition("ScalingDown", "True", "ScalingDown", "Scaling down"),
+				NewCondition("ScalingUp", "False", "NotScalingUp", ""),
+			},
+			expectedState:    "updating",
+			expectedTransit:  true,
+			expectedError:    false,
+			expectedMessages: nil,
+		},
+		{
+			name: "Deleting=True takes priority over active scale-down",
+			obj:  makeClusterObj(1, 1, 1, 1),
+			conditions: []Condition{
+				NewCondition("Deleting", "True", "WaitingForWorkersDeletion", "cleanup in progress"),
+				NewCondition("Paused", "False", "NotPaused", ""),
+				NewCondition("ScalingDown", "True", "ScalingDown", "Scaling down from 1 to 0"),
+				NewCondition("Available", "False", "NotAvailable", "not available"),
+			},
+			expectedState:    "deleting",
+			expectedTransit:  true,
+			expectedError:    false,
+			expectedMessages: []string{"cleanup in progress"},
+		},
+		{
+			name: "Paused=True takes priority over scale-up detected by replicas",
+			obj:  makeClusterObj(3, 1, 1, 1),
+			conditions: []Condition{
+				NewCondition("Deleting", "False", "NotDeleting", ""),
+				NewCondition("Paused", "True", "Paused", ""),
+				NewCondition("ScalingDown", "False", "NotScalingDown", ""),
+				NewCondition("ScalingUp", "False", "NotScalingUp", ""),
+			},
+			expectedState:   "paused",
+			expectedTransit: true,
+			expectedError:   false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := checkCAPIClusterTransitioning(tt.obj, tt.conditions, Summary{})
+			assert.Equal(t, tt.expectedState, result.State, "state mismatch")
+			assert.Equal(t, tt.expectedTransit, result.Transitioning, "transitioning mismatch")
+			assert.Equal(t, tt.expectedError, result.Error, "error mismatch")
+			if tt.expectedMessages != nil {
+				assert.Equal(t, tt.expectedMessages, result.Message, "messages mismatch")
+			} else {
+				assert.Empty(t, result.Message, "expected no messages")
+			}
+		})
+	}
+}
+
+// TestCheckTransitioning_CAPIClusterDispatch verifies that checkTransitioning
+// dispatches to checkCAPIClusterTransitioning for CAPI Clusters and not to
+// the generic path.
+func TestCheckTransitioning_CAPIClusterDispatch(t *testing.T) {
+	// A CAPI Cluster with ScalingUp=True should get "updating" from the
+	// CAPI Cluster path.
+	capiObj := makeClusterObj(2, 1, 1, 1)
+	conditions := []Condition{
+		NewCondition("ScalingUp", "True", "ScalingUp", "* MachineDeployment md: Scaling up from 1 to 2 replicas"),
+		NewCondition("ScalingDown", "False", "NotScalingDown", ""),
+		NewCondition("Deleting", "False", "NotDeleting", ""),
+		NewCondition("Paused", "False", "NotPaused", ""),
+		NewCondition("Available", "False", "NotAvailable", "something"),
+	}
+	result := checkTransitioning(capiObj, conditions, Summary{})
+	assert.Equal(t, "updating", result.State)
+	assert.True(t, result.Transitioning)
+
+	// A non-CAPI Cluster (e.g. management.cattle.io) should use the generic path.
+	genericObj := data.Object{
+		"apiVersion": "management.cattle.io/v3",
+		"kind":       "Cluster",
+	}
+	genericConditions := []Condition{
+		NewCondition("Available", "False", "MinimumReplicasUnavailable", "not available"),
+	}
+	genericResult := checkTransitioning(genericObj, genericConditions, Summary{})
+	assert.Equal(t, "updating", genericResult.State)
+	assert.True(t, genericResult.Transitioning)
+}

--- a/pkg/summary/capi_machine_test.go
+++ b/pkg/summary/capi_machine_test.go
@@ -1,0 +1,560 @@
+package summary
+
+import (
+	"testing"
+
+	"github.com/rancher/wrangler/v3/pkg/data"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestIsCAPIMachine(t *testing.T) {
+	tests := []struct {
+		name     string
+		obj      data.Object
+		expected bool
+	}{
+		{
+			name: "CAPI v1beta2 Machine",
+			obj: data.Object{
+				"apiVersion": "cluster.x-k8s.io/v1beta2",
+				"kind":       "Machine",
+			},
+			expected: true,
+		},
+		{
+			name: "CAPI v1beta1 Machine",
+			obj: data.Object{
+				"apiVersion": "cluster.x-k8s.io/v1beta1",
+				"kind":       "Machine",
+			},
+			expected: true,
+		},
+		{
+			name: "CAPI v1beta2 Cluster",
+			obj: data.Object{
+				"apiVersion": "cluster.x-k8s.io/v1beta2",
+				"kind":       "Cluster",
+			},
+			expected: false,
+		},
+		{
+			name: "CAPI v1beta2 MachineSet",
+			obj: data.Object{
+				"apiVersion": "cluster.x-k8s.io/v1beta2",
+				"kind":       "MachineSet",
+			},
+			expected: false,
+		},
+		{
+			name: "non-CAPI Machine kind",
+			obj: data.Object{
+				"apiVersion": "apps/v1",
+				"kind":       "Deployment",
+			},
+			expected: false,
+		},
+		{
+			name:     "empty object",
+			obj:      data.Object{},
+			expected: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.expected, isCAPIMachine(tt.obj))
+		})
+	}
+}
+
+func TestParseReadyFirstBullet(t *testing.T) {
+	tests := []struct {
+		name           string
+		message        string
+		expectedDetail string
+		expectedPrefix string
+	}{
+		{
+			name:           "empty message",
+			message:        "",
+			expectedDetail: "",
+			expectedPrefix: "",
+		},
+		{
+			name:           "single bullet BootstrapConfigReady",
+			message:        "* BootstrapConfigReady: RKEBootstrap status.initialization.dataSecretCreated is false",
+			expectedDetail: "RKEBootstrap status.initialization.dataSecretCreated is false",
+			expectedPrefix: "BootstrapConfigReady",
+		},
+		{
+			name:           "single bullet InfrastructureReady",
+			message:        "* InfrastructureReady: creating server of kind (DigitaloceanMachine)",
+			expectedDetail: "creating server of kind (DigitaloceanMachine)",
+			expectedPrefix: "InfrastructureReady",
+		},
+		{
+			name:           "single bullet NodeHealthy",
+			message:        "* NodeHealthy: Waiting for Cluster control plane to be initialized",
+			expectedDetail: "Waiting for Cluster control plane to be initialized",
+			expectedPrefix: "NodeHealthy",
+		},
+		{
+			name:           "multiple bullets - takes first only",
+			message:        "* BootstrapConfigReady: bootstrap not ready\n* InfrastructureReady: infra not ready\n* NodeHealthy: waiting",
+			expectedDetail: "bootstrap not ready",
+			expectedPrefix: "BootstrapConfigReady",
+		},
+		{
+			name:           "multiple bullets starting with InfrastructureReady",
+			message:        "* InfrastructureReady: creating server...\n* NodeHealthy: Waiting for CP init",
+			expectedDetail: "creating server...",
+			expectedPrefix: "InfrastructureReady",
+		},
+		{
+			name:           "no bullet prefix",
+			message:        "some plain message",
+			expectedDetail: "some plain message",
+			expectedPrefix: "",
+		},
+		{
+			name:           "bullet without colon separator",
+			message:        "* SomeCondition without colon",
+			expectedDetail: "SomeCondition without colon",
+			expectedPrefix: "",
+		},
+		{
+			name:           "nested sub-bullet: NodeHealthy with empty inline detail",
+			message:        "* NodeHealthy:\n  * Node.AllConditions: Kubelet stopped posting node status.",
+			expectedDetail: "Kubelet stopped posting node status.",
+			expectedPrefix: "NodeHealthy",
+		},
+		{
+			name:           "nested sub-bullet: multiple sub-bullets takes first",
+			message:        "* NodeHealthy:\n  * Node.AllConditions: first issue\n  * Node.OtherCondition: second issue",
+			expectedDetail: "first issue",
+			expectedPrefix: "NodeHealthy",
+		},
+		{
+			name:           "nested sub-bullet: sub-bullet without colon separator",
+			message:        "* NodeHealthy:\n  * some plain sub-bullet",
+			expectedDetail: "some plain sub-bullet",
+			expectedPrefix: "NodeHealthy",
+		},
+		{
+			name:           "nested sub-bullet: InfrastructureReady with empty inline detail",
+			message:        "* InfrastructureReady:\n  * SubCondition: infra detail here",
+			expectedDetail: "infra detail here",
+			expectedPrefix: "InfrastructureReady",
+		},
+		{
+			name:           "nested sub-bullet: no sub-bullets found (only non-bullet lines)",
+			message:        "* NodeHealthy:\n  some non-bullet line",
+			expectedDetail: "",
+			expectedPrefix: "NodeHealthy",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			detail, prefix := parseReadyFirstBullet(tt.message)
+			assert.Equal(t, tt.expectedDetail, detail)
+			assert.Equal(t, tt.expectedPrefix, prefix)
+		})
+	}
+}
+
+func TestCheckCAPIMachineTransitioning(t *testing.T) {
+	tests := []struct {
+		name             string
+		conditions       []Condition
+		expectedState    string
+		expectedTransit  bool
+		expectedError    bool
+		expectedMessages []string
+	}{
+		// --- Priority 1: Deleting ---
+		{
+			name: "Deleting=True takes absolute priority",
+			conditions: []Condition{
+				NewCondition("Reconciled", "Unknown", "Waiting", "reconciling something"),
+				NewCondition("Deleting", "True", "Deleting", "machine is being deleted"),
+				NewCondition("Ready", "False", "NotReady", "* InfrastructureReady: infra not ready"),
+			},
+			expectedState:    "deleting",
+			expectedTransit:  true,
+			expectedError:    false,
+			expectedMessages: []string{"machine is being deleted"},
+		},
+		{
+			name: "Deleting=True with empty message",
+			conditions: []Condition{
+				NewCondition("Deleting", "True", "Deleting", ""),
+			},
+			expectedState:    "deleting",
+			expectedTransit:  true,
+			expectedError:    false,
+			expectedMessages: nil,
+		},
+		{
+			name: "Deleting=True with drain message rewrite",
+			conditions: []Condition{
+				NewCondition("Deleting", "True", "Draining", "Drain not completed yet (1/3 nodes drained)"),
+			},
+			expectedState:    "deleting",
+			expectedTransit:  true,
+			expectedError:    false,
+			expectedMessages: []string{"Draining node"},
+		},
+
+		// --- Priority 2: Paused ---
+		{
+			name: "Paused=True takes priority over Reconciled and Ready",
+			conditions: []Condition{
+				NewCondition("Reconciled", "Unknown", "Waiting", "reconciling"),
+				NewCondition("Paused", "True", "Paused", "machine is paused"),
+				NewCondition("Ready", "False", "NotReady", "* InfrastructureReady: infra not ready"),
+			},
+			expectedState:   "paused",
+			expectedTransit: true,
+			expectedError:   false,
+		},
+		{
+			name: "Paused=False is ignored (normal state)",
+			conditions: []Condition{
+				NewCondition("Paused", "False", "NotPaused", ""),
+				NewCondition("Deleting", "False", "NotDeleting", ""),
+				NewCondition("Ready", "True", "Ready", ""),
+			},
+			expectedState:   "",
+			expectedTransit: false,
+			expectedError:   false,
+		},
+
+		// --- Priority 3: Reconciled not True ---
+		{
+			name: "Reconciled=Unknown → reconciling with message",
+			conditions: []Condition{
+				NewCondition("Ready", "Unknown", "ReadyUnknown", "* NodeHealthy: waiting"),
+				NewCondition("Reconciled", "Unknown", "Waiting", "waiting for agent to check in and apply initial plan"),
+				NewCondition("Paused", "False", "NotPaused", ""),
+				NewCondition("Deleting", "False", "NotDeleting", ""),
+			},
+			expectedState:    "reconciling",
+			expectedTransit:  true,
+			expectedError:    false,
+			expectedMessages: []string{"waiting for agent to check in and apply initial plan"},
+		},
+		{
+			name: "Reconciled=Unknown with empty message",
+			conditions: []Condition{
+				NewCondition("Ready", "Unknown", "ReadyUnknown", "* NodeHealthy: waiting"),
+				NewCondition("Reconciled", "Unknown", "Waiting", ""),
+				NewCondition("Paused", "False", "NotPaused", ""),
+				NewCondition("Deleting", "False", "NotDeleting", ""),
+			},
+			expectedState:   "reconciling",
+			expectedTransit: true,
+			expectedError:   false,
+		},
+		{
+			name: "Reconciled=False → reconciling with error",
+			conditions: []Condition{
+				NewCondition("Ready", "True", "Ready", ""),
+				NewCondition("Reconciled", "False", "ReconcileError", "failed to reconcile machine"),
+				NewCondition("Paused", "False", "NotPaused", ""),
+				NewCondition("Deleting", "False", "NotDeleting", ""),
+			},
+			expectedState:    "reconciling",
+			expectedTransit:  false,
+			expectedError:    true,
+			expectedMessages: []string{"failed to reconcile machine"},
+		},
+		{
+			name: "Reconciled=False with empty message → reconciling with error, no messages",
+			conditions: []Condition{
+				NewCondition("Ready", "True", "Ready", ""),
+				NewCondition("Reconciled", "False", "ReconcileError", ""),
+				NewCondition("Paused", "False", "NotPaused", ""),
+				NewCondition("Deleting", "False", "NotDeleting", ""),
+			},
+			expectedState:    "reconciling",
+			expectedTransit:  false,
+			expectedError:    true,
+			expectedMessages: nil,
+		},
+		{
+			name: "Reconciled=Unknown takes priority over Ready=False",
+			conditions: []Condition{
+				NewCondition("Ready", "False", "NotReady", "* InfrastructureReady: infra not ready"),
+				NewCondition("Reconciled", "Unknown", "Waiting", "reconciling"),
+				NewCondition("Paused", "False", "NotPaused", ""),
+				NewCondition("Deleting", "False", "NotDeleting", ""),
+			},
+			expectedState:    "reconciling",
+			expectedTransit:  true,
+			expectedError:    false,
+			expectedMessages: []string{"reconciling"},
+		},
+
+		// --- Priority 4: Ready=False ---
+		{
+			name: "Ready=False, first bullet BootstrapConfigReady → waitingforinfrastructure",
+			conditions: []Condition{
+				NewCondition("Ready", "False", "NotReady",
+					"* BootstrapConfigReady: RKEBootstrap status.initialization.dataSecretCreated is false\n"+
+						"* InfrastructureReady: DigitaloceanMachine status.initialization.provisioned is false\n"+
+						"* NodeHealthy: Waiting for Cluster control plane to be initialized"),
+				NewCondition("Paused", "False", "NotPaused", ""),
+				NewCondition("Deleting", "False", "NotDeleting", ""),
+			},
+			expectedState:    "waitingforinfrastructure",
+			expectedTransit:  true,
+			expectedError:    false,
+			expectedMessages: nil,
+		},
+		{
+			name: "Ready=False, first bullet InfrastructureReady → waitingfornoderef",
+			conditions: []Condition{
+				NewCondition("Ready", "False", "NotReady",
+					"* InfrastructureReady: creating server [fleet-default/prod-jiaqi-pa-qxwqc-9gdk2] of kind (DigitaloceanMachine) for machine prod-jiaqi-pa-qxwqc-9gdk2 in infrastructure provider\n"+
+						"* NodeHealthy: Waiting for Cluster control plane to be initialized"),
+				NewCondition("Paused", "False", "NotPaused", ""),
+				NewCondition("Deleting", "False", "NotDeleting", ""),
+			},
+			expectedState:    "waitingfornoderef",
+			expectedTransit:  true,
+			expectedError:    false,
+			expectedMessages: []string{"creating server [fleet-default/prod-jiaqi-pa-qxwqc-9gdk2] of kind (DigitaloceanMachine) for machine prod-jiaqi-pa-qxwqc-9gdk2 in infrastructure provider"},
+		},
+		{
+			name: "Ready=False, unknown first bullet → pass through (no state set)",
+			conditions: []Condition{
+				NewCondition("Ready", "False", "NotReady", "* SomeOtherCondition: something happened"),
+				NewCondition("Paused", "False", "NotPaused", ""),
+				NewCondition("Deleting", "False", "NotDeleting", ""),
+			},
+			expectedState:   "",
+			expectedTransit: false,
+			expectedError:   false,
+		},
+		{
+			name: "Ready=False, InfrastructureReady detail suppressed when ending with 'status.initialization.provisioned is false'",
+			conditions: []Condition{
+				NewCondition("Ready", "False", "NotReady",
+					"* InfrastructureReady: DigitaloceanMachine status.initialization.provisioned is false\n"+
+						"* NodeHealthy: Waiting for Cluster control plane to be initialized"),
+				NewCondition("Paused", "False", "NotPaused", ""),
+				NewCondition("Deleting", "False", "NotDeleting", ""),
+			},
+			expectedState:   "waitingfornoderef",
+			expectedTransit: true,
+			expectedError:   false,
+			// Detail is suppressed — no messages expected.
+		},
+		{
+			name: "Ready=False with empty message → pass through",
+			conditions: []Condition{
+				NewCondition("Ready", "False", "NotReady", ""),
+				NewCondition("Paused", "False", "NotPaused", ""),
+				NewCondition("Deleting", "False", "NotDeleting", ""),
+			},
+			expectedState:   "",
+			expectedTransit: false,
+			expectedError:   false,
+		},
+
+		// --- Priority 5: Ready=Unknown ---
+		{
+			name: "Ready=Unknown with NodeHealthy bullet → reconciling",
+			conditions: []Condition{
+				NewCondition("Ready", "Unknown", "ReadyUnknown", "* NodeHealthy: Waiting for Cluster control plane to be initialized"),
+				NewCondition("Paused", "False", "NotPaused", ""),
+				NewCondition("Deleting", "False", "NotDeleting", ""),
+			},
+			expectedState:    "reconciling",
+			expectedTransit:  true,
+			expectedError:    false,
+			expectedMessages: []string{"Waiting for Cluster control plane to be initialized"},
+		},
+		{
+			name: "Ready=Unknown, Reconciled=True → reconciling (rule 5, not rule 3)",
+			conditions: []Condition{
+				NewCondition("Ready", "Unknown", "ReadyUnknown", "* NodeHealthy: Waiting for Cluster control plane to be initialized"),
+				NewCondition("Reconciled", "True", "Reconciled", ""),
+				NewCondition("Paused", "False", "NotPaused", ""),
+				NewCondition("Deleting", "False", "NotDeleting", ""),
+			},
+			expectedState:    "reconciling",
+			expectedTransit:  true,
+			expectedError:    false,
+			expectedMessages: []string{"Waiting for Cluster control plane to be initialized"},
+		},
+		{
+			name: "Ready=Unknown with multiple bullets → reconciling with first bullet detail",
+			conditions: []Condition{
+				NewCondition("Ready", "Unknown", "ReadyUnknown", "* InfrastructureReady: some issue\n* NodeHealthy: waiting"),
+				NewCondition("Paused", "False", "NotPaused", ""),
+				NewCondition("Deleting", "False", "NotDeleting", ""),
+			},
+			expectedState:    "reconciling",
+			expectedTransit:  true,
+			expectedError:    false,
+			expectedMessages: []string{"some issue"},
+		},
+		{
+			name: "Ready=Unknown with nested sub-bullet (NodeHealthy empty detail) → reconciling with sub-bullet detail",
+			conditions: []Condition{
+				NewCondition("Ready", "Unknown", "ReadyUnknown", "* NodeHealthy:\n  * Node.AllConditions: Kubelet stopped posting node status."),
+				NewCondition("Reconciled", "True", "Reconciled", ""),
+				NewCondition("Paused", "False", "NotPaused", ""),
+				NewCondition("Deleting", "False", "NotDeleting", ""),
+			},
+			expectedState:    "reconciling",
+			expectedTransit:  true,
+			expectedError:    false,
+			expectedMessages: []string{"Kubelet stopped posting node status."},
+		},
+		{
+			name: "Ready=Unknown with NodeHealthy detail suppressed when ending with 'to report spec.providerID'",
+			conditions: []Condition{
+				NewCondition("Ready", "Unknown", "ReadyUnknown", "* NodeHealthy: Waiting for Node controller to report spec.providerID"),
+				NewCondition("Paused", "False", "NotPaused", ""),
+				NewCondition("Deleting", "False", "NotDeleting", ""),
+			},
+			expectedState:   "reconciling",
+			expectedTransit: true,
+			expectedError:   false,
+			// Detail is suppressed because it ends with "to report spec.providerID".
+		},
+		{
+			name: "Ready=Unknown with empty message → reconciling with no messages",
+			conditions: []Condition{
+				NewCondition("Ready", "Unknown", "ReadyUnknown", ""),
+				NewCondition("Paused", "False", "NotPaused", ""),
+				NewCondition("Deleting", "False", "NotDeleting", ""),
+			},
+			expectedState:   "reconciling",
+			expectedTransit: true,
+			expectedError:   false,
+		},
+
+		// --- Priority 6: Ready=True ---
+		{
+			name: "Ready=True → pass through (no state set)",
+			conditions: []Condition{
+				NewCondition("Ready", "True", "Ready", ""),
+				NewCondition("Reconciled", "True", "Reconciled", ""),
+				NewCondition("Paused", "False", "NotPaused", ""),
+				NewCondition("Deleting", "False", "NotDeleting", ""),
+			},
+			expectedState:   "",
+			expectedTransit: false,
+			expectedError:   false,
+		},
+
+		// --- Edge cases ---
+		{
+			name:            "no conditions → pass through",
+			conditions:      []Condition{},
+			expectedState:   "",
+			expectedTransit: false,
+			expectedError:   false,
+		},
+		{
+			name: "no Ready or Reconciled conditions → pass through",
+			conditions: []Condition{
+				NewCondition("Paused", "False", "NotPaused", ""),
+				NewCondition("Deleting", "False", "NotDeleting", ""),
+			},
+			expectedState:   "",
+			expectedTransit: false,
+			expectedError:   false,
+		},
+		{
+			name: "Reconciled=True is skipped (not a problem state)",
+			conditions: []Condition{
+				NewCondition("Ready", "True", "Ready", ""),
+				NewCondition("Reconciled", "True", "Reconciled", ""),
+			},
+			expectedState:   "",
+			expectedTransit: false,
+			expectedError:   false,
+		},
+		{
+			name: "Deleting=False does not trigger removing",
+			conditions: []Condition{
+				NewCondition("Deleting", "False", "NotDeleting", ""),
+				NewCondition("Ready", "True", "Ready", ""),
+				NewCondition("Reconciled", "True", "Reconciled", ""),
+			},
+			expectedState:   "",
+			expectedTransit: false,
+			expectedError:   false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := checkCAPIMachineTransitioning(tt.conditions, Summary{})
+			assert.Equal(t, tt.expectedState, result.State)
+			assert.Equal(t, tt.expectedTransit, result.Transitioning)
+			assert.Equal(t, tt.expectedError, result.Error)
+			if tt.expectedMessages != nil {
+				assert.Equal(t, tt.expectedMessages, result.Message)
+			} else {
+				assert.Empty(t, result.Message)
+			}
+		})
+	}
+}
+
+// TestCheckTransitioning_CAPIMachineDispatch verifies that checkTransitioning
+// dispatches to checkCAPIMachineTransitioning for CAPI Machines and to
+// checkGenericTransitioning for everything else.
+func TestCheckTransitioning_CAPIMachineDispatch(t *testing.T) {
+	// A CAPI Machine with Reconciled=Unknown should get "reconciling" from
+	// the CAPI path, not the generic TransitioningUnknown path.
+	capiObj := data.Object{
+		"apiVersion": "cluster.x-k8s.io/v1beta2",
+		"kind":       "Machine",
+	}
+	conditions := []Condition{
+		NewCondition("Reconciled", "Unknown", "Waiting", "waiting for agent"),
+		NewCondition("Ready", "Unknown", "ReadyUnknown", "* NodeHealthy: waiting"),
+		NewCondition("Paused", "False", "NotPaused", ""),
+		NewCondition("Deleting", "False", "NotDeleting", ""),
+	}
+	result := checkTransitioning(capiObj, conditions, Summary{})
+	assert.Equal(t, "reconciling", result.State)
+	assert.True(t, result.Transitioning)
+
+	// A non-CAPI object with Reconciled=Unknown should use the generic path.
+	// In TransitioningUnknown, Reconciled maps to "reconciling" for Unknown status.
+	genericObj := data.Object{
+		"apiVersion": "management.cattle.io/v3",
+		"kind":       "Cluster",
+	}
+	genericConditions := []Condition{
+		NewCondition("Reconciled", "Unknown", "Waiting", "waiting for something"),
+	}
+	genericResult := checkTransitioning(genericObj, genericConditions, Summary{})
+	assert.Equal(t, "reconciling", genericResult.State)
+	assert.True(t, genericResult.Transitioning)
+}
+
+// TestCheckTransitioning_NonCAPIMachineUnchanged verifies that the generic
+// path remains unchanged for non-CAPI objects.
+func TestCheckTransitioning_NonCAPIMachineUnchanged(t *testing.T) {
+	obj := data.Object{
+		"apiVersion": "apps/v1",
+		"kind":       "Deployment",
+	}
+	// Available=False in TransitioningFalse maps to "updating"
+	conditions := []Condition{
+		NewCondition("Available", "False", "MinimumReplicasUnavailable", "Deployment does not have minimum availability"),
+	}
+	result := checkTransitioning(obj, conditions, Summary{})
+	assert.Equal(t, "updating", result.State)
+	assert.True(t, result.Transitioning)
+	assert.False(t, result.Error)
+}

--- a/pkg/summary/capi_machine_test.go
+++ b/pkg/summary/capi_machine_test.go
@@ -67,7 +67,7 @@ func TestIsCAPIMachine(t *testing.T) {
 	}
 }
 
-func TestParseReadyFirstBullet(t *testing.T) {
+func TestParseMessage(t *testing.T) {
 	tests := []struct {
 		name           string
 		message        string
@@ -156,7 +156,7 @@ func TestParseReadyFirstBullet(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			detail, prefix := parseReadyFirstBullet(tt.message)
+			detail, prefix := parseMessage(tt.message)
 			assert.Equal(t, tt.expectedDetail, detail)
 			assert.Equal(t, tt.expectedPrefix, prefix)
 		})

--- a/pkg/summary/capi_machineset_test.go
+++ b/pkg/summary/capi_machineset_test.go
@@ -88,6 +88,30 @@ func makeMachineSetObj(specReplicas, statusReplicas, readyReplicas int64) data.O
 	return obj
 }
 
+// makeMachineDeploymentObj builds a minimal CAPI MachineDeployment data.Object
+// with the given replica fields. Use -1 to omit a field.
+func makeMachineDeploymentObj(specReplicas, statusReplicas, readyReplicas, upToDateReplicas int64) data.Object {
+	obj := data.Object{
+		"apiVersion": "cluster.x-k8s.io/v1beta2",
+		"kind":       "MachineDeployment",
+		"spec":       map[string]interface{}{},
+		"status":     map[string]interface{}{},
+	}
+	if specReplicas >= 0 {
+		obj["spec"].(map[string]interface{})["replicas"] = specReplicas
+	}
+	if statusReplicas >= 0 {
+		obj["status"].(map[string]interface{})["replicas"] = statusReplicas
+	}
+	if readyReplicas >= 0 {
+		obj["status"].(map[string]interface{})["readyReplicas"] = readyReplicas
+	}
+	if upToDateReplicas >= 0 {
+		obj["status"].(map[string]interface{})["upToDateReplicas"] = upToDateReplicas
+	}
+	return obj
+}
+
 func TestCheckCAPIMachineSetAndDeploymentTransitioning(t *testing.T) {
 	tests := []struct {
 		name             string
@@ -166,7 +190,40 @@ func TestCheckCAPIMachineSetAndDeploymentTransitioning(t *testing.T) {
 			expectedError:   false,
 		},
 
-		// --- Priority 3: ScalingDown ---
+		// --- Priority 3: RollingOut ---
+		// RollingOut only applies to MachineDeployment, not MachineSet.
+		{
+			name: "RollingOut=True on MachineDeployment takes priority over ScalingDown",
+			obj:  makeMachineDeploymentObj(3, 4, 3, 2),
+			conditions: []Condition{
+				NewCondition("Deleting", "False", "NotDeleting", ""),
+				NewCondition("Paused", "False", "NotPaused", ""),
+				NewCondition("RollingOut", "True", "RollingOut", "Rolling out 2 not up-to-date replicas\n* DigitaloceanMachine is not up-to-date"),
+				NewCondition("ScalingDown", "True", "ScalingDown", "Scaling down from 4 to 3 replicas"),
+				NewCondition("ScalingUp", "False", "NotScalingUp", ""),
+			},
+			expectedState:    "rollingout",
+			expectedTransit:  true,
+			expectedError:    false,
+			expectedMessages: []string{"rolling out 2 not up-to-date replicas"},
+		},
+		{
+			name: "RollingOut=True on MachineDeployment takes priority over ScalingUp by replicas",
+			obj:  makeMachineDeploymentObj(3, 3, 1, 1),
+			conditions: []Condition{
+				NewCondition("Deleting", "False", "NotDeleting", ""),
+				NewCondition("Paused", "False", "NotPaused", ""),
+				NewCondition("RollingOut", "True", "RollingOut", "Rolling out 2 not up-to-date replicas"),
+				NewCondition("ScalingDown", "False", "NotScalingDown", ""),
+				NewCondition("ScalingUp", "False", "NotScalingUp", ""),
+			},
+			expectedState:    "rollingout",
+			expectedTransit:  true,
+			expectedError:    false,
+			expectedMessages: []string{"rolling out 2 not up-to-date replicas"},
+		},
+
+		// --- Priority 4: ScalingDown ---
 		{
 			name: "ScalingDown=True — message always constructed from replicas",
 			obj:  makeMachineSetObj(1, 2, 2),
@@ -239,7 +296,7 @@ func TestCheckCAPIMachineSetAndDeploymentTransitioning(t *testing.T) {
 			expectedMessages: []string{"Scaling down from 3 to 1 replicas, waiting for machines to be deleted"},
 		},
 
-		// --- Priority 4: ScalingUp ---
+		// --- Priority 5: ScalingUp ---
 		{
 			name: "ScalingUp=True — message always constructed from replicas",
 			obj:  makeMachineSetObj(2, 1, 1),
@@ -283,7 +340,7 @@ func TestCheckCAPIMachineSetAndDeploymentTransitioning(t *testing.T) {
 			expectedMessages: []string{"Scaling up from 1 to 2 replicas, waiting for machines to be ready"},
 		},
 		{
-			name: "ScalingUp detected by readyReplicas mismatch",
+			name: "Spec replicas exceed ready replicas — reports scalingup even when all machines exist",
 			obj:  makeMachineSetObj(2, 2, 1),
 			conditions: []Condition{
 				NewCondition("Deleting", "False", "NotDeleting", ""),
@@ -296,6 +353,78 @@ func TestCheckCAPIMachineSetAndDeploymentTransitioning(t *testing.T) {
 			expectedTransit:  true,
 			expectedError:    false,
 			expectedMessages: []string{"Scaling up from 1 to 2 replicas, waiting for machines to be ready"},
+		},
+		{
+			name: "MachineDeployment with ready replicas below spec — reports scalingup before other conditions",
+			obj:  makeMachineDeploymentObj(3, 3, 2, 3),
+			conditions: []Condition{
+				NewCondition("Deleting", "False", "NotDeleting", ""),
+				NewCondition("Paused", "False", "NotPaused", ""),
+				NewCondition("RollingOut", "False", "NotRollingOut", ""),
+				NewCondition("ScalingDown", "False", "NotScalingDown", ""),
+				NewCondition("ScalingUp", "False", "NotScalingUp", ""),
+				NewCondition("Available", "False", "NotAvailable", "2 available replicas, at least 3 required"),
+				NewCondition("MachinesReady", "Unknown", "ReadyUnknown", "* Machine test-m:\n  * NodeHealthy: Kubelet stopped posting node status"),
+			},
+			expectedState:    "scalingup",
+			expectedTransit:  true,
+			expectedError:    false,
+			expectedMessages: []string{"Scaling up from 2 to 3 replicas, waiting for machines to be ready"},
+		},
+		{
+			name: "Deleting=True takes priority over RollingOut=True",
+			obj:  makeMachineDeploymentObj(3, 4, 3, 2),
+			conditions: []Condition{
+				NewCondition("Deleting", "True", "Deleting", "being deleted"),
+				NewCondition("RollingOut", "True", "RollingOut", "Rolling out 2 not up-to-date replicas"),
+				NewCondition("ScalingDown", "True", "ScalingDown", "Scaling down from 4 to 3 replicas"),
+			},
+			expectedState:    "deleting",
+			expectedTransit:  true,
+			expectedError:    false,
+			expectedMessages: []string{"being deleted"},
+		},
+		{
+			name: "Paused=True takes priority over RollingOut=True",
+			obj:  makeMachineDeploymentObj(3, 4, 3, 2),
+			conditions: []Condition{
+				NewCondition("Deleting", "False", "NotDeleting", ""),
+				NewCondition("Paused", "True", "Paused", ""),
+				NewCondition("RollingOut", "True", "RollingOut", "Rolling out 2 not up-to-date replicas"),
+				NewCondition("ScalingDown", "True", "ScalingDown", "Scaling down from 4 to 3 replicas"),
+			},
+			expectedState:   "paused",
+			expectedTransit: true,
+			expectedError:   false,
+		},
+		{
+			name: "RollingOut=False does not trigger rollingout — falls through to ScalingDown",
+			obj:  makeMachineDeploymentObj(1, 2, 2, -1),
+			conditions: []Condition{
+				NewCondition("Deleting", "False", "NotDeleting", ""),
+				NewCondition("Paused", "False", "NotPaused", ""),
+				NewCondition("RollingOut", "False", "NotRollingOut", ""),
+				NewCondition("ScalingDown", "True", "ScalingDown", "Scaling down from 2 to 1 replicas"),
+				NewCondition("ScalingUp", "False", "NotScalingUp", ""),
+			},
+			expectedState:    "scalingdown",
+			expectedTransit:  true,
+			expectedError:    false,
+			expectedMessages: []string{"Scaling down from 2 to 1 replicas, waiting for machines to be deleted"},
+		},
+		{
+			name: "RollingOut=True on MachineDeployment with missing upToDateReplicas — no message",
+			obj:  makeMachineDeploymentObj(3, 4, 3, -1),
+			conditions: []Condition{
+				NewCondition("Deleting", "False", "NotDeleting", ""),
+				NewCondition("Paused", "False", "NotPaused", ""),
+				NewCondition("RollingOut", "True", "RollingOut", "Rolling out 2 not up-to-date replicas"),
+				NewCondition("ScalingDown", "True", "ScalingDown", "Scaling down from 4 to 3 replicas"),
+			},
+			expectedState:    "rollingout",
+			expectedTransit:  true,
+			expectedError:    false,
+			expectedMessages: nil,
 		},
 
 		// --- Pass through (steady state) ---
@@ -509,9 +638,9 @@ func TestIsCAPIMachineDeployment(t *testing.T) {
 // checkCAPIMachineSetAndDeploymentTransitioning and that the replica-field
 // paths behave correctly for deployments (not just MachineSets).
 func TestCheckTransitioning_CAPIMachineDeploymentDispatch(t *testing.T) {
-	// A MachineDeployment scaling up: spec.replicas=3, status.readyReplicas=1.
+	// A MachineDeployment scaling up: spec.replicas=3, status.replicas=1.
 	// Even with ScalingUp=False (stale condition), the replica mismatch
-	// should be detected via the CAPI handler.
+	// (spec > status) should be detected via the CAPI handler.
 	scalingObj := data.Object{
 		"apiVersion": "cluster.x-k8s.io/v1beta2",
 		"kind":       "MachineDeployment",
@@ -519,7 +648,7 @@ func TestCheckTransitioning_CAPIMachineDeploymentDispatch(t *testing.T) {
 			"replicas": int64(3),
 		},
 		"status": map[string]interface{}{
-			"replicas":      int64(3),
+			"replicas":      int64(1),
 			"readyReplicas": int64(1),
 		},
 	}
@@ -557,4 +686,30 @@ func TestCheckTransitioning_CAPIMachineDeploymentDispatch(t *testing.T) {
 	assert.Empty(t, steadyResult.State, "steady-state MachineDeployment should pass through")
 	assert.False(t, steadyResult.Transitioning)
 	assert.False(t, steadyResult.Error)
+
+	// A MachineDeployment doing a rolling upgrade: RollingOut=True should
+	// take priority over the ScalingDown condition and replica mismatch.
+	rollingObj := data.Object{
+		"apiVersion": "cluster.x-k8s.io/v1beta2",
+		"kind":       "MachineDeployment",
+		"spec": map[string]interface{}{
+			"replicas": int64(3),
+		},
+		"status": map[string]interface{}{
+			"replicas":         int64(4),
+			"readyReplicas":    int64(3),
+			"upToDateReplicas": int64(2),
+		},
+	}
+	rollingConditions := []Condition{
+		NewCondition("Deleting", "False", "NotDeleting", ""),
+		NewCondition("Paused", "False", "NotPaused", ""),
+		NewCondition("RollingOut", "True", "RollingOut", "Rolling out 2 not up-to-date replicas"),
+		NewCondition("ScalingDown", "True", "ScalingDown", "Scaling down from 4 to 3 replicas"),
+		NewCondition("ScalingUp", "False", "NotScalingUp", ""),
+	}
+	rollingResult := checkTransitioning(rollingObj, rollingConditions, Summary{})
+	assert.Equal(t, "rollingout", rollingResult.State, "rolling upgrade should produce state=rollingout")
+	assert.True(t, rollingResult.Transitioning)
+	assert.Equal(t, []string{"rolling out 2 not up-to-date replicas"}, rollingResult.Message)
 }

--- a/pkg/summary/capi_machineset_test.go
+++ b/pkg/summary/capi_machineset_test.go
@@ -1,0 +1,505 @@
+package summary
+
+import (
+	"testing"
+
+	"github.com/rancher/wrangler/v3/pkg/data"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestIsCAPIMachineSet(t *testing.T) {
+	tests := []struct {
+		name     string
+		obj      data.Object
+		expected bool
+	}{
+		{
+			name: "CAPI v1beta2 MachineSet",
+			obj: data.Object{
+				"apiVersion": "cluster.x-k8s.io/v1beta2",
+				"kind":       "MachineSet",
+			},
+			expected: true,
+		},
+		{
+			name: "CAPI v1beta1 MachineSet",
+			obj: data.Object{
+				"apiVersion": "cluster.x-k8s.io/v1beta1",
+				"kind":       "MachineSet",
+			},
+			expected: true,
+		},
+		{
+			name: "CAPI v1beta2 Machine (not MachineSet)",
+			obj: data.Object{
+				"apiVersion": "cluster.x-k8s.io/v1beta2",
+				"kind":       "Machine",
+			},
+			expected: false,
+		},
+		{
+			name: "CAPI v1beta2 Cluster",
+			obj: data.Object{
+				"apiVersion": "cluster.x-k8s.io/v1beta2",
+				"kind":       "Cluster",
+			},
+			expected: false,
+		},
+		{
+			name: "non-CAPI MachineSet kind",
+			obj: data.Object{
+				"apiVersion": "apps/v1",
+				"kind":       "ReplicaSet",
+			},
+			expected: false,
+		},
+		{
+			name:     "empty object",
+			obj:      data.Object{},
+			expected: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.expected, isCAPIMachineSet(tt.obj))
+		})
+	}
+}
+
+// makeMachineSetObj builds a minimal CAPI MachineSet data.Object with the
+// given replica fields. Use -1 to omit a field (simulating it not being set).
+func makeMachineSetObj(specReplicas, statusReplicas, readyReplicas int64) data.Object {
+	obj := data.Object{
+		"apiVersion": "cluster.x-k8s.io/v1beta2",
+		"kind":       "MachineSet",
+		"spec":       map[string]interface{}{},
+		"status":     map[string]interface{}{},
+	}
+	if specReplicas >= 0 {
+		obj["spec"].(map[string]interface{})["replicas"] = specReplicas
+	}
+	if statusReplicas >= 0 {
+		obj["status"].(map[string]interface{})["replicas"] = statusReplicas
+	}
+	if readyReplicas >= 0 {
+		obj["status"].(map[string]interface{})["readyReplicas"] = readyReplicas
+	}
+	return obj
+}
+
+func TestCheckCAPIMachineSetAndDeploymentTransitioning(t *testing.T) {
+	tests := []struct {
+		name             string
+		obj              data.Object
+		conditions       []Condition
+		expectedState    string
+		expectedTransit  bool
+		expectedError    bool
+		expectedMessages []string
+	}{
+		// --- Priority 1: Deleting ---
+		{
+			name: "Deleting=True takes absolute priority",
+			obj:  makeMachineSetObj(2, 2, 2),
+			conditions: []Condition{
+				NewCondition("Deleting", "True", "Deleting", "machineset is being deleted"),
+				NewCondition("ScalingUp", "True", "ScalingUp", "Scaling up from 1 to 2 replicas"),
+				NewCondition("Paused", "False", "NotPaused", ""),
+			},
+			expectedState:    "deleting",
+			expectedTransit:  true,
+			expectedError:    false,
+			expectedMessages: []string{"machineset is being deleted"},
+		},
+		{
+			name: "Deleting=True with empty message",
+			obj:  makeMachineSetObj(2, 2, 2),
+			conditions: []Condition{
+				NewCondition("Deleting", "True", "Deleting", ""),
+			},
+			expectedState:    "deleting",
+			expectedTransit:  true,
+			expectedError:    false,
+			expectedMessages: nil,
+		},
+		{
+			name: "Deleting=False is ignored",
+			obj:  makeMachineSetObj(2, 2, 2),
+			conditions: []Condition{
+				NewCondition("Deleting", "False", "NotDeleting", ""),
+				NewCondition("ScalingDown", "False", "NotScalingDown", ""),
+				NewCondition("ScalingUp", "False", "NotScalingUp", ""),
+				NewCondition("Paused", "False", "NotPaused", ""),
+				NewCondition("MachinesReady", "True", "Ready", ""),
+			},
+			expectedState:   "",
+			expectedTransit: false,
+			expectedError:   false,
+		},
+
+		// --- Priority 2: Paused ---
+		{
+			name: "Paused=True takes priority over scaling conditions",
+			obj:  makeMachineSetObj(2, 1, 1),
+			conditions: []Condition{
+				NewCondition("Paused", "True", "Paused", "machineset is paused"),
+				NewCondition("ScalingUp", "True", "ScalingUp", "Scaling up from 1 to 2 replicas"),
+				NewCondition("Deleting", "False", "NotDeleting", ""),
+			},
+			expectedState:   "paused",
+			expectedTransit: true,
+			expectedError:   false,
+		},
+		{
+			name: "Paused=False is ignored",
+			obj:  makeMachineSetObj(2, 2, 2),
+			conditions: []Condition{
+				NewCondition("Paused", "False", "NotPaused", ""),
+				NewCondition("Deleting", "False", "NotDeleting", ""),
+				NewCondition("ScalingDown", "False", "NotScalingDown", ""),
+				NewCondition("ScalingUp", "False", "NotScalingUp", ""),
+				NewCondition("MachinesReady", "True", "Ready", ""),
+			},
+			expectedState:   "",
+			expectedTransit: false,
+			expectedError:   false,
+		},
+
+		// --- Priority 3: ScalingDown ---
+		{
+			name: "ScalingDown=True — message always constructed from replicas",
+			obj:  makeMachineSetObj(1, 2, 2),
+			conditions: []Condition{
+				NewCondition("Deleting", "False", "NotDeleting", ""),
+				NewCondition("Paused", "False", "NotPaused", ""),
+				NewCondition("ScalingDown", "True", "ScalingDown", "Scaling down from 2 to 1 replicas"),
+				NewCondition("ScalingUp", "False", "NotScalingUp", ""),
+			},
+			expectedState:    "scalingdown",
+			expectedTransit:  true,
+			expectedError:    false,
+			expectedMessages: []string{"Scaling down from 2 to 1 replicas, waiting for machines to be deleted"},
+		},
+		{
+			name: "ScalingDown=True with empty condition message — constructs from replicas",
+			obj:  makeMachineSetObj(1, 2, 2),
+			conditions: []Condition{
+				NewCondition("Deleting", "False", "NotDeleting", ""),
+				NewCondition("Paused", "False", "NotPaused", ""),
+				NewCondition("ScalingDown", "True", "ScalingDown", ""),
+				NewCondition("ScalingUp", "False", "NotScalingUp", ""),
+			},
+			expectedState:    "scalingdown",
+			expectedTransit:  true,
+			expectedError:    false,
+			expectedMessages: []string{"Scaling down from 2 to 1 replicas, waiting for machines to be deleted"},
+		},
+		{
+			name: "ScalingDown detected by replica mismatch only (stale condition)",
+			obj:  makeMachineSetObj(1, 2, 2),
+			conditions: []Condition{
+				NewCondition("Deleting", "False", "NotDeleting", ""),
+				NewCondition("Paused", "False", "NotPaused", ""),
+				NewCondition("ScalingDown", "False", "NotScalingDown", ""),
+				NewCondition("ScalingUp", "False", "NotScalingUp", ""),
+			},
+			expectedState:    "scalingdown",
+			expectedTransit:  true,
+			expectedError:    false,
+			expectedMessages: []string{"Scaling down from 2 to 1 replicas, waiting for machines to be deleted"},
+		},
+		{
+			name: "ScalingDown detected by replica mismatch",
+			obj:  makeMachineSetObj(1, 2, 1),
+			conditions: []Condition{
+				NewCondition("Deleting", "False", "NotDeleting", ""),
+				NewCondition("Paused", "False", "NotPaused", ""),
+				NewCondition("ScalingDown", "False", "NotScalingDown", ""),
+				NewCondition("ScalingUp", "False", "NotScalingUp", ""),
+				NewCondition("MachinesReady", "True", "Ready", ""),
+			},
+			expectedState:    "scalingdown",
+			expectedTransit:  true,
+			expectedError:    false,
+			expectedMessages: []string{"Scaling down from 2 to 1 replicas, waiting for machines to be deleted"},
+		},
+		{
+			name: "ScalingDown takes priority over ScalingUp when both detectable",
+			obj:  makeMachineSetObj(1, 3, 0),
+			conditions: []Condition{
+				NewCondition("Deleting", "False", "NotDeleting", ""),
+				NewCondition("Paused", "False", "NotPaused", ""),
+				NewCondition("ScalingDown", "True", "ScalingDown", "Scaling down from 3 to 1 replicas"),
+				NewCondition("ScalingUp", "False", "NotScalingUp", ""),
+			},
+			expectedState:    "scalingdown",
+			expectedTransit:  true,
+			expectedError:    false,
+			expectedMessages: []string{"Scaling down from 3 to 1 replicas, waiting for machines to be deleted"},
+		},
+
+		// --- Priority 4: ScalingUp ---
+		{
+			name: "ScalingUp=True — message always constructed from replicas",
+			obj:  makeMachineSetObj(2, 1, 1),
+			conditions: []Condition{
+				NewCondition("Deleting", "False", "NotDeleting", ""),
+				NewCondition("Paused", "False", "NotPaused", ""),
+				NewCondition("ScalingDown", "False", "NotScalingDown", ""),
+				NewCondition("ScalingUp", "True", "ScalingUp", "Scaling up from 1 to 2 replicas"),
+			},
+			expectedState:    "scalingup",
+			expectedTransit:  true,
+			expectedError:    false,
+			expectedMessages: []string{"Scaling up from 1 to 2 replicas, waiting for machines to be ready"},
+		},
+		{
+			name: "ScalingUp=True with empty condition message — constructs from replicas",
+			obj:  makeMachineSetObj(2, 1, 1),
+			conditions: []Condition{
+				NewCondition("Deleting", "False", "NotDeleting", ""),
+				NewCondition("Paused", "False", "NotPaused", ""),
+				NewCondition("ScalingDown", "False", "NotScalingDown", ""),
+				NewCondition("ScalingUp", "True", "ScalingUp", ""),
+			},
+			expectedState:    "scalingup",
+			expectedTransit:  true,
+			expectedError:    false,
+			expectedMessages: []string{"Scaling up from 1 to 2 replicas, waiting for machines to be ready"},
+		},
+		{
+			name: "ScalingUp detected by readyReplicas mismatch only",
+			obj:  makeMachineSetObj(2, 1, 1),
+			conditions: []Condition{
+				NewCondition("Deleting", "False", "NotDeleting", ""),
+				NewCondition("Paused", "False", "NotPaused", ""),
+				NewCondition("ScalingDown", "False", "NotScalingDown", ""),
+				NewCondition("ScalingUp", "False", "NotScalingUp", ""),
+			},
+			expectedState:    "scalingup",
+			expectedTransit:  true,
+			expectedError:    false,
+			expectedMessages: []string{"Scaling up from 1 to 2 replicas, waiting for machines to be ready"},
+		},
+		{
+			name: "ScalingUp detected by readyReplicas mismatch",
+			obj:  makeMachineSetObj(2, 2, 1),
+			conditions: []Condition{
+				NewCondition("Deleting", "False", "NotDeleting", ""),
+				NewCondition("Paused", "False", "NotPaused", ""),
+				NewCondition("ScalingDown", "False", "NotScalingDown", ""),
+				NewCondition("ScalingUp", "False", "NotScalingUp", ""),
+				NewCondition("MachinesReady", "True", "Ready", ""),
+			},
+			expectedState:    "scalingup",
+			expectedTransit:  true,
+			expectedError:    false,
+			expectedMessages: []string{"Scaling up from 1 to 2 replicas, waiting for machines to be ready"},
+		},
+
+		// --- Pass through (steady state) ---
+		{
+			name: "Steady state — all replicas match → pass through",
+			obj:  makeMachineSetObj(2, 2, 2),
+			conditions: []Condition{
+				NewCondition("Deleting", "False", "NotDeleting", ""),
+				NewCondition("Paused", "False", "NotPaused", ""),
+				NewCondition("ScalingDown", "False", "NotScalingDown", ""),
+				NewCondition("ScalingUp", "False", "NotScalingUp", ""),
+				NewCondition("MachinesReady", "True", "Ready", ""),
+			},
+			expectedState:   "",
+			expectedTransit: false,
+			expectedError:   false,
+		},
+
+		// --- Edge cases ---
+		{
+			name:            "No conditions → pass through",
+			obj:             makeMachineSetObj(1, 1, 1),
+			conditions:      []Condition{},
+			expectedState:   "",
+			expectedTransit: false,
+			expectedError:   false,
+		},
+		{
+			name: "Missing replica fields → pass through (no panic)",
+			obj: data.Object{
+				"apiVersion": "cluster.x-k8s.io/v1beta2",
+				"kind":       "MachineSet",
+			},
+			conditions: []Condition{
+				NewCondition("Deleting", "False", "NotDeleting", ""),
+				NewCondition("Paused", "False", "NotPaused", ""),
+				NewCondition("ScalingDown", "False", "NotScalingDown", ""),
+				NewCondition("ScalingUp", "False", "NotScalingUp", ""),
+			},
+			expectedState:   "",
+			expectedTransit: false,
+			expectedError:   false,
+		},
+		{
+			name: "ScalingUp=True but no replica fields → scalingup, no message",
+			obj: data.Object{
+				"apiVersion": "cluster.x-k8s.io/v1beta2",
+				"kind":       "MachineSet",
+			},
+			conditions: []Condition{
+				NewCondition("Deleting", "False", "NotDeleting", ""),
+				NewCondition("Paused", "False", "NotPaused", ""),
+				NewCondition("ScalingDown", "False", "NotScalingDown", ""),
+				NewCondition("ScalingUp", "True", "ScalingUp", ""),
+			},
+			expectedState:    "scalingup",
+			expectedTransit:  true,
+			expectedError:    false,
+			expectedMessages: nil,
+		},
+		{
+			name: "ScalingUp from zero readyReplicas",
+			obj:  makeMachineSetObj(2, 0, 0),
+			conditions: []Condition{
+				NewCondition("Deleting", "False", "NotDeleting", ""),
+				NewCondition("Paused", "False", "NotPaused", ""),
+				NewCondition("ScalingDown", "False", "NotScalingDown", ""),
+				NewCondition("ScalingUp", "True", "ScalingUp", ""),
+			},
+			expectedState:    "scalingup",
+			expectedTransit:  true,
+			expectedError:    false,
+			expectedMessages: []string{"Scaling up from 0 to 2 replicas, waiting for machines to be ready"},
+		},
+		{
+			name: "ScalingUp with larger replica counts (3 → 5)",
+			obj:  makeMachineSetObj(5, 3, 3),
+			conditions: []Condition{
+				NewCondition("Deleting", "False", "NotDeleting", ""),
+				NewCondition("Paused", "False", "NotPaused", ""),
+				NewCondition("ScalingDown", "False", "NotScalingDown", ""),
+				NewCondition("ScalingUp", "True", "ScalingUp", ""),
+			},
+			expectedState:    "scalingup",
+			expectedTransit:  true,
+			expectedError:    false,
+			expectedMessages: []string{"Scaling up from 3 to 5 replicas, waiting for machines to be ready"},
+		},
+		{
+			name: "Deleting=True takes priority over active scale-down",
+			obj:  makeMachineSetObj(1, 2, 2),
+			conditions: []Condition{
+				NewCondition("Deleting", "True", "Deleting", "machineset cleanup in progress"),
+				NewCondition("Paused", "False", "NotPaused", ""),
+				NewCondition("ScalingDown", "True", "ScalingDown", "Scaling down from 2 to 1 replicas"),
+			},
+			expectedState:    "deleting",
+			expectedTransit:  true,
+			expectedError:    false,
+			expectedMessages: []string{"machineset cleanup in progress"},
+		},
+		{
+			name: "Paused=True takes priority over scale-up detected by replicas",
+			obj:  makeMachineSetObj(3, 1, 1),
+			conditions: []Condition{
+				NewCondition("Deleting", "False", "NotDeleting", ""),
+				NewCondition("Paused", "True", "Paused", ""),
+				NewCondition("ScalingDown", "False", "NotScalingDown", ""),
+				NewCondition("ScalingUp", "False", "NotScalingUp", ""),
+			},
+			expectedState:   "paused",
+			expectedTransit: true,
+			expectedError:   false,
+		},
+		{
+			name: "ScalingDown=True but no replica fields → scalingdown, no message",
+			obj: data.Object{
+				"apiVersion": "cluster.x-k8s.io/v1beta2",
+				"kind":       "MachineSet",
+			},
+			conditions: []Condition{
+				NewCondition("Deleting", "False", "NotDeleting", ""),
+				NewCondition("Paused", "False", "NotPaused", ""),
+				NewCondition("ScalingDown", "True", "ScalingDown", ""),
+				NewCondition("ScalingUp", "False", "NotScalingUp", ""),
+			},
+			expectedState:    "scalingdown",
+			expectedTransit:  true,
+			expectedError:    false,
+			expectedMessages: nil,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := checkCAPIMachineSetAndDeploymentTransitioning(tt.obj, tt.conditions, Summary{})
+			assert.Equal(t, tt.expectedState, result.State, "state mismatch")
+			assert.Equal(t, tt.expectedTransit, result.Transitioning, "transitioning mismatch")
+			assert.Equal(t, tt.expectedError, result.Error, "error mismatch")
+			if tt.expectedMessages != nil {
+				assert.Equal(t, tt.expectedMessages, result.Message, "messages mismatch")
+			} else {
+				assert.Empty(t, result.Message, "expected no messages")
+			}
+		})
+	}
+}
+
+func TestIsCAPIMachineDeployment(t *testing.T) {
+	tests := []struct {
+		name     string
+		obj      data.Object
+		expected bool
+	}{
+		{
+			name: "CAPI v1beta2 MachineDeployment",
+			obj: data.Object{
+				"apiVersion": "cluster.x-k8s.io/v1beta2",
+				"kind":       "MachineDeployment",
+			},
+			expected: true,
+		},
+		{
+			name: "CAPI v1beta1 MachineDeployment",
+			obj: data.Object{
+				"apiVersion": "cluster.x-k8s.io/v1beta1",
+				"kind":       "MachineDeployment",
+			},
+			expected: true,
+		},
+		{
+			name: "CAPI v1beta2 MachineSet (not MachineDeployment)",
+			obj: data.Object{
+				"apiVersion": "cluster.x-k8s.io/v1beta2",
+				"kind":       "MachineSet",
+			},
+			expected: false,
+		},
+		{
+			name: "CAPI v1beta2 Cluster",
+			obj: data.Object{
+				"apiVersion": "cluster.x-k8s.io/v1beta2",
+				"kind":       "Cluster",
+			},
+			expected: false,
+		},
+		{
+			name: "non-CAPI Deployment kind",
+			obj: data.Object{
+				"apiVersion": "apps/v1",
+				"kind":       "Deployment",
+			},
+			expected: false,
+		},
+		{
+			name:     "empty object",
+			obj:      data.Object{},
+			expected: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.expected, isCAPIMachineDeployment(tt.obj))
+		})
+	}
+}

--- a/pkg/summary/capi_machineset_test.go
+++ b/pkg/summary/capi_machineset_test.go
@@ -503,3 +503,58 @@ func TestIsCAPIMachineDeployment(t *testing.T) {
 		})
 	}
 }
+
+// TestCheckTransitioning_CAPIMachineDeploymentDispatch verifies that
+// checkTransitioning dispatches CAPI MachineDeployment objects to
+// checkCAPIMachineSetAndDeploymentTransitioning and that the replica-field
+// paths behave correctly for deployments (not just MachineSets).
+func TestCheckTransitioning_CAPIMachineDeploymentDispatch(t *testing.T) {
+	// A MachineDeployment scaling up: spec.replicas=3, status.readyReplicas=1.
+	// Even with ScalingUp=False (stale condition), the replica mismatch
+	// should be detected via the CAPI handler.
+	scalingObj := data.Object{
+		"apiVersion": "cluster.x-k8s.io/v1beta2",
+		"kind":       "MachineDeployment",
+		"spec": map[string]interface{}{
+			"replicas": int64(3),
+		},
+		"status": map[string]interface{}{
+			"replicas":      int64(3),
+			"readyReplicas": int64(1),
+		},
+	}
+	conditions := []Condition{
+		NewCondition("Deleting", "False", "NotDeleting", ""),
+		NewCondition("Paused", "False", "NotPaused", ""),
+		NewCondition("ScalingDown", "False", "NotScalingDown", ""),
+		NewCondition("ScalingUp", "False", "NotScalingUp", ""),
+	}
+	result := checkTransitioning(scalingObj, conditions, Summary{})
+	assert.Equal(t, "scalingup", result.State)
+	assert.True(t, result.Transitioning)
+	assert.Equal(t, []string{"Scaling up from 1 to 3 replicas, waiting for machines to be ready"}, result.Message)
+
+	// A MachineDeployment in steady state: all replicas match.
+	steadyObj := data.Object{
+		"apiVersion": "cluster.x-k8s.io/v1beta2",
+		"kind":       "MachineDeployment",
+		"spec": map[string]interface{}{
+			"replicas": int64(2),
+		},
+		"status": map[string]interface{}{
+			"replicas":      int64(2),
+			"readyReplicas": int64(2),
+		},
+	}
+	steadyConditions := []Condition{
+		NewCondition("Deleting", "False", "NotDeleting", ""),
+		NewCondition("Paused", "False", "NotPaused", ""),
+		NewCondition("ScalingDown", "False", "NotScalingDown", ""),
+		NewCondition("ScalingUp", "False", "NotScalingUp", ""),
+		NewCondition("MachinesReady", "True", "Ready", ""),
+	}
+	steadyResult := checkTransitioning(steadyObj, steadyConditions, Summary{})
+	assert.Empty(t, steadyResult.State, "steady-state MachineDeployment should pass through")
+	assert.False(t, steadyResult.Transitioning)
+	assert.False(t, steadyResult.Error)
+}

--- a/pkg/summary/summarizers.go
+++ b/pkg/summary/summarizers.go
@@ -503,9 +503,10 @@ func checkCAPIMachineTransitioning(conditions []Condition, summary Summary) Summ
 // Priority order (first match wins):
 //  1. Deleting=True                                          -> state="deleting", transitioning=true
 //  2. Paused=True                                            -> state="paused", transitioning=true
-//  3. ScalingDown=True OR status.replicas > spec.replicas    -> state="scalingdown", transitioning=true
-//  4. ScalingUp=True OR spec.replicas > status.readyReplicas -> state="scalingup", transitioning=true
-//  5. Otherwise                                              -> pass through (no state set)
+//  3. RollingOut=True                                        -> state="rollingout", transitioning=true
+//  4. ScalingDown=True OR status.replicas > spec.replicas    -> state="scalingdown", transitioning=true
+//  5. ScalingUp=True OR spec.replicas > status.readyReplicas -> state="scalingup", transitioning=true
+//  6. Otherwise                                              -> pass through (no state set)
 func checkCAPIMachineSetAndDeploymentTransitioning(obj data.Object, conditions []Condition, summary Summary) Summary {
 	// Read replica counts from the object. We use nestedInt64 instead of
 	// unstructured.NestedInt64 because YAML/JSON decoders store numbers as
@@ -513,9 +514,11 @@ func checkCAPIMachineSetAndDeploymentTransitioning(obj data.Object, conditions [
 	specReplicas, specFound, _ := nestedInt64(obj, "spec", "replicas")
 	statusReplicas, statusFound, _ := nestedInt64(obj, "status", "replicas")
 	readyReplicas, readyFound, _ := nestedInt64(obj, "status", "readyReplicas")
+	upToDateReplicas, upToDateFound, _ := nestedInt64(obj, "status", "upToDateReplicas")
 
 	var scalingUp *Condition
 	var scalingDown *Condition
+	var rollingOut *Condition
 
 	for i := range conditions {
 		c := conditions[i]
@@ -541,10 +544,28 @@ func checkCAPIMachineSetAndDeploymentTransitioning(obj data.Object, conditions [
 			scalingUp = &conditions[i]
 		case "ScalingDown":
 			scalingDown = &conditions[i]
+		case "RollingOut":
+			rollingOut = &conditions[i]
 		}
 	}
 
-	// Priority 3: Scaling down — detected by condition OR replica count mismatch.
+	// Priority 3: Rolling out — RollingOut=True indicates a rolling upgrade
+	// is in progress. This takes priority over ScalingDown/ScalingUp because
+	// those are side effects of the rollout strategy (maxSurge creates extra
+	// machines, then old ones are deleted). Only MachineDeployments have
+	// rolling upgrades; MachineSets do not set this condition.
+	if rollingOut != nil && rollingOut.Status() == "True" {
+		summary.State = "rollingout"
+		summary.Transitioning = true
+		if statusFound && upToDateFound {
+			notUpToDate := statusReplicas - upToDateReplicas
+			summary.Message = append(summary.Message,
+				fmt.Sprintf("rolling out %d not up-to-date replicas", notUpToDate))
+		}
+		return summary
+	}
+
+	// Priority 4: Scaling down — detected by condition OR replica count mismatch.
 	scalingDownByCondition := scalingDown != nil && scalingDown.Status() == "True"
 	scalingDownByReplicas := specFound && statusFound && statusReplicas > specReplicas
 	if scalingDownByCondition || scalingDownByReplicas {
@@ -557,7 +578,7 @@ func checkCAPIMachineSetAndDeploymentTransitioning(obj data.Object, conditions [
 		return summary
 	}
 
-	// Priority 4: Scaling up — detected by spec.replicas > status.readyReplicas.
+	// Priority 5: Scaling up — detected by spec.replicas > status.readyReplicas.
 	// This catches both the transient ScalingUp=True period and the long tail
 	// where ScalingUp has already gone False but the new machine isn't ready yet.
 	scalingUpByReplicas := specFound && readyFound && specReplicas > readyReplicas
@@ -583,21 +604,24 @@ func checkCAPIMachineSetAndDeploymentTransitioning(obj data.Object, conditions [
 // ControlPlaneInitialized, etc. Worker replica counts are under status.workers.*.
 //
 // Priority order (first match wins):
-//  1. Deleting=True                                                           -> state="deleting", transitioning=true
-//  2. Paused=True                                                             -> state="paused", transitioning=true
-//  3. ScalingDown=True OR status.workers.replicas > status.workers.desiredReplicas -> state="updating", transitioning=true
-//  4. ScalingUp=True OR status.workers.desiredReplicas > status.workers.readyReplicas -> state="updating", transitioning=true
-//  5. Available=False                                                         -> state="updating", transitioning=true
-//  6. Available=True (or any other case)                                      -> pass through (no state set)
+//  1. Deleting=True                                                                    -> state="deleting", transitioning=true
+//  2. Paused=True                                                                      -> state="paused", transitioning=true
+//  3. RollingOut=True                                                                  -> state="rollingout", transitioning=true
+//  4. ScalingDown=True OR status.workers.replicas > status.workers.desiredReplicas     -> state="updating", transitioning=true
+//  5. ScalingUp=True OR status.workers.desiredReplicas > status.workers.readyReplicas  -> state="updating", transitioning=true
+//  6. Available=False                                                                  -> state="updating", transitioning=true
+//  7. Available=True (or any other case)                                               -> pass through (no state set)
 func checkCAPIClusterTransitioning(obj data.Object, conditions []Condition, summary Summary) Summary {
 	// Read worker replica counts from status.workers.*.
 	desiredReplicas, desiredFound, _ := nestedInt64(obj, "status", "workers", "desiredReplicas")
 	workersReplicas, workersFound, _ := nestedInt64(obj, "status", "workers", "replicas")
 	readyReplicas, readyFound, _ := nestedInt64(obj, "status", "workers", "readyReplicas")
+	upToDateReplicas, upToDateFound, _ := nestedInt64(obj, "status", "workers", "upToDateReplicas")
 
 	var scalingUp *Condition
 	var scalingDown *Condition
 	var available *Condition
+	var rollingOut *Condition
 
 	for i := range conditions {
 		c := conditions[i]
@@ -628,10 +652,27 @@ func checkCAPIClusterTransitioning(obj data.Object, conditions []Condition, summ
 			scalingDown = &conditions[i]
 		case "Available":
 			available = &conditions[i]
+		case "RollingOut":
+			rollingOut = &conditions[i]
 		}
 	}
 
-	// Priority 3: Scaling down — detected by condition OR replica count mismatch.
+	// Priority 3: Rolling out — RollingOut=True indicates one or more
+	// MachineDeployments are performing a rolling upgrade. This takes
+	// priority over ScalingDown/ScalingUp because those are side effects
+	// of the rollout strategy.
+	if rollingOut != nil && rollingOut.Status() == "True" {
+		summary.State = "rollingout"
+		summary.Transitioning = true
+		if workersFound && upToDateFound {
+			notUpToDate := workersReplicas - upToDateReplicas
+			summary.Message = append(summary.Message,
+				fmt.Sprintf("rolling out %d not up-to-date replicas", notUpToDate))
+		}
+		return summary
+	}
+
+	// Priority 4: Scaling down — detected by condition OR replica count mismatch.
 	scalingDownByCondition := scalingDown != nil && scalingDown.Status() == "True"
 	scalingDownByReplicas := desiredFound && workersFound && workersReplicas > desiredReplicas
 	if scalingDownByCondition || scalingDownByReplicas {
@@ -644,7 +685,7 @@ func checkCAPIClusterTransitioning(obj data.Object, conditions []Condition, summ
 		return summary
 	}
 
-	// Priority 4: Scaling up — detected by condition OR desired > readyReplicas.
+	// Priority 5: Scaling up — Scaling up — detected by condition OR desired > readyReplicas.
 	scalingUpByCondition := scalingUp != nil && scalingUp.Status() == "True"
 	scalingUpByReplicas := desiredFound && readyFound && desiredReplicas > readyReplicas
 	if scalingUpByCondition || scalingUpByReplicas {

--- a/pkg/summary/summarizers.go
+++ b/pkg/summary/summarizers.go
@@ -2,6 +2,7 @@ package summary
 
 import (
 	"encoding/json"
+	"fmt"
 	"os"
 	"strings"
 	"time"
@@ -67,8 +68,8 @@ var (
 		"AbleToScale":                 "pending",
 		"RunCompleted":                "running",
 		"Processed":                   "processed",
-		"NodeHealthy":                 reason, // CAPI Machine
-		"NodeReady":                   reason, // CAPI Machine
+		// "NodeHealthy":                 reason, // CAPI Machine
+		// "NodeReady":                   reason, // CAPI Machine
 	}
 
 	// For given GVK, This condition Type and this Status, indicates an error or not
@@ -107,12 +108,12 @@ var (
 	// False == transitioning
 	// Unknown == error
 	TransitioningFalse = map[string]string{
-		"Completed":            "activating",
-		"Ready":                "unavailable",
-		"Available":            "updating",
-		"BootstrapConfigReady": reason,     // CAPI Machine
-		"InfrastructureReady":  reason,     // CAPI Machine
-		"MachinesReady":        "updating", // CAPI MachineDeployment, MachineSet
+		"Completed": "activating",
+		"Ready":     "unavailable",
+		"Available": "updating",
+		// "BootstrapConfigReady": reason,     // CAPI Machine
+		// "InfrastructureReady":  reason,     // CAPI Machine
+		// "MachinesReady":        "updating", // CAPI MachineDeployment, MachineSet
 	}
 
 	// True == transitioning
@@ -120,10 +121,10 @@ var (
 	// Unknown == error
 	TransitioningTrue = map[string]string{
 		"Reconciling": "reconciling",
-		"ScalingUp":   reason, // CAPI Cluster, MachineDeployment, MachineSet
-		"ScalingDown": reason, // CAPI Cluster, MachineDeployment, MachineSet
-		"Deleting":    reason, // CAPI Cluster, MachineDeployment, MachineSet, Machine
-		"Paused":      reason, // CAPI Cluster, MachineDeployment, MachineSet, Machine
+		// "ScalingUp":   reason, // CAPI Cluster, MachineDeployment, MachineSet
+		// "ScalingDown": reason, // CAPI Cluster, MachineDeployment, MachineSet
+		// "Deleting":    reason, // CAPI Cluster, MachineDeployment, MachineSet, Machine
+		// "Paused":      reason, // CAPI Cluster, MachineDeployment, MachineSet, Machine
 	}
 
 	Summarizers          []Summarizer
@@ -358,7 +359,339 @@ func checkErrors(data data.Object, conditions []Condition, summary Summary) Summ
 	return summary
 }
 
-func checkTransitioning(_ data.Object, conditions []Condition, summary Summary) Summary {
+func checkTransitioning(obj data.Object, conditions []Condition, summary Summary) Summary {
+	if isCAPIMachine(obj) {
+		return checkCAPIMachineTransitioning(conditions, summary)
+	}
+	if isCAPIMachineSet(obj) || isCAPIMachineDeployment(obj) {
+		return checkCAPIMachineSetAndDeploymentTransitioning(obj, conditions, summary)
+	}
+	if isCAPICluster(obj) {
+		return checkCAPIClusterTransitioning(obj, conditions, summary)
+	}
+	return checkGenericTransitioning(obj, conditions, summary)
+}
+
+// checkCAPIMachineTransitioning computes summary state for CAPI Machine objects
+// using the Ready (aggregate) and Reconciled conditions from v1beta2.
+//
+// The Ready condition is a composite condition whose message aggregates
+// sub-condition issues as bullet points (e.g., "* InfrastructureReady: <detail>").
+// The Reconciled condition is a Rancher-specific condition that indicates
+// whether the machine's desired state has been fully applied.
+//
+// Priority order (first match wins):
+//  1. Deleting=True -> state="deleting", transitioning=true
+//  2. Paused=True   -> state="paused", transitioning=true
+//  3. Reconciled present and NOT True -> state="reconciling",
+//     message=Reconciled.message(if has message), transitioning=true(if status=Unknown), error=true(if status=False)
+//  4. Ready=False (NotReady) — parse first bullet of Ready.message:
+//     a. First bullet starts with "* BootstrapConfigReady:" -> state="waitingforinfrastructure"
+//     b. First bullet starts with "* InfrastructureReady:"  -> state="waitingfornoderef"
+//     c. Otherwise -> pass through (no state set)
+//     Message is the stripped detail text from the first bullet.
+//  5. Ready=Unknown -> state="reconciling", message=stripped detail from first
+//     bullet of Ready.message, transitioning=true
+//  6. Ready=True (or any other case) -> pass through, no state set
+func checkCAPIMachineTransitioning(conditions []Condition, summary Summary) Summary {
+	var reconciled *Condition
+	var ready *Condition
+
+	for i := range conditions {
+		c := conditions[i]
+		typ := c.Type()
+
+		// Check Deleting and Paused first — these take absolute priority.
+		if typ == "Deleting" && c.Status() == "True" {
+			summary.State = "deleting"
+			summary.Transitioning = true
+			if msg := c.Message(); msg != "" {
+				if strings.HasPrefix(msg, "Drain not completed yet") {
+					msg = "Draining node"
+				}
+				summary.Message = append(summary.Message, msg)
+			}
+			return summary
+		}
+		if typ == "Paused" && c.Status() == "True" {
+			summary.State = "paused"
+			summary.Transitioning = true
+			return summary
+		}
+
+		// Collect key conditions for priority evaluation below.
+		switch typ {
+		case "Reconciled":
+			reconciled = &conditions[i]
+		case "Ready":
+			ready = &conditions[i]
+		}
+	}
+
+	// Priority 3: Reconciled condition (when present and not True).
+	if reconciled != nil && reconciled.Status() != "True" {
+		switch reconciled.Status() {
+		case "Unknown":
+			summary.Transitioning = true
+			summary.State = "reconciling"
+		case "False":
+			summary.Error = true
+			summary.State = "reconciling"
+		}
+		if msg := reconciled.Message(); msg != "" {
+			summary.Message = append(summary.Message, msg)
+		}
+		return summary
+	}
+
+	// Priority 4 & 5: Ready condition.
+	if ready != nil {
+		switch ready.Status() {
+		case "False":
+			// Parse the first bullet line to determine the state.
+			detail, prefix := parseReadyFirstBullet(ready.Message())
+			switch prefix {
+			case "BootstrapConfigReady":
+				summary.Transitioning = true
+				summary.State = "waitingforinfrastructure"
+				if strings.HasSuffix(detail, "status.initialization.dataSecretCreated is false") {
+					detail = ""
+				}
+				if detail != "" {
+					summary.Message = append(summary.Message, detail)
+				}
+			case "InfrastructureReady":
+				summary.Transitioning = true
+				summary.State = "waitingfornoderef"
+				if strings.HasSuffix(detail, "status.initialization.provisioned is false") {
+					detail = ""
+				}
+				if detail != "" {
+					summary.Message = append(summary.Message, detail)
+				}
+			}
+			// If the first bullet doesn't match known patterns, pass through.
+			return summary
+
+		case "Unknown":
+			summary.Transitioning = true
+			summary.State = "reconciling"
+			detail, prefix := parseReadyFirstBullet(ready.Message())
+			if prefix == "NodeHealthy" {
+				if strings.HasSuffix(detail, "to report spec.providerID") {
+					detail = ""
+				}
+			}
+			if detail != "" {
+				summary.Message = append(summary.Message, detail)
+			}
+			return summary
+		}
+		// Ready=True: pass through, let downstream summarizers handle it.
+	}
+
+	return summary
+}
+
+// checkCAPIMachineSetAndDeploymentTransitioning computes summary state for CAPI MachineSet
+// and MachineDeployment objects using v1beta2 conditions and replica counts.
+//
+// The function reads spec.replicas, status.replicas, and status.readyReplicas
+// to detect scaling operations, even when the controller hasn't yet updated
+// the ScalingUp/ScalingDown conditions (stale observedGeneration).
+//
+// Priority order (first match wins):
+//  1. Deleting=True                                          -> state="deleting", transitioning=true
+//  2. Paused=True                                            -> state="paused", transitioning=true
+//  3. ScalingDown=True OR status.replicas > spec.replicas    -> state="scalingdown", transitioning=true
+//  4. ScalingUp=True OR spec.replicas > status.readyReplicas -> state="scalingup", transitioning=true
+//  5. Otherwise                                              -> pass through (no state set)
+func checkCAPIMachineSetAndDeploymentTransitioning(obj data.Object, conditions []Condition, summary Summary) Summary {
+	// Read replica counts from the object. We use nestedInt64 instead of
+	// unstructured.NestedInt64 because YAML/JSON decoders store numbers as
+	// float64, not int64.
+	specReplicas, specFound, _ := nestedInt64(obj, "spec", "replicas")
+	statusReplicas, statusFound, _ := nestedInt64(obj, "status", "replicas")
+	readyReplicas, readyFound, _ := nestedInt64(obj, "status", "readyReplicas")
+
+	var scalingUp *Condition
+	var scalingDown *Condition
+
+	for i := range conditions {
+		c := conditions[i]
+		typ := c.Type()
+
+		// Priority 1 & 2: Deleting and Paused take absolute priority.
+		if typ == "Deleting" && c.Status() == "True" {
+			summary.State = "deleting"
+			summary.Transitioning = true
+			if msg := c.Message(); msg != "" {
+				summary.Message = append(summary.Message, msg)
+			}
+			return summary
+		}
+		if typ == "Paused" && c.Status() == "True" {
+			summary.State = "paused"
+			summary.Transitioning = true
+			return summary
+		}
+
+		switch typ {
+		case "ScalingUp":
+			scalingUp = &conditions[i]
+		case "ScalingDown":
+			scalingDown = &conditions[i]
+		}
+	}
+
+	// Priority 3: Scaling down — detected by condition OR replica count mismatch.
+	scalingDownByCondition := scalingDown != nil && scalingDown.Status() == "True"
+	scalingDownByReplicas := specFound && statusFound && statusReplicas > specReplicas
+	if scalingDownByCondition || scalingDownByReplicas {
+		summary.State = "scalingdown"
+		summary.Transitioning = true
+		if specFound && statusFound {
+			summary.Message = append(summary.Message,
+				fmt.Sprintf("Scaling down from %d to %d replicas, waiting for machines to be deleted", statusReplicas, specReplicas))
+		}
+		return summary
+	}
+
+	// Priority 4: Scaling up — detected by spec.replicas > status.readyReplicas.
+	// This catches both the transient ScalingUp=True period and the long tail
+	// where ScalingUp has already gone False but the new machine isn't ready yet.
+	scalingUpByReplicas := specFound && readyFound && specReplicas > readyReplicas
+	scalingUpByCondition := scalingUp != nil && scalingUp.Status() == "True"
+	if scalingUpByReplicas || scalingUpByCondition {
+		summary.State = "scalingup"
+		summary.Transitioning = true
+		if specFound && readyFound {
+			summary.Message = append(summary.Message,
+				fmt.Sprintf("Scaling up from %d to %d replicas, waiting for machines to be ready", readyReplicas, specReplicas))
+		}
+		return summary
+	}
+
+	return summary
+}
+
+// checkCAPIClusterTransitioning computes summary state for CAPI Cluster objects
+// using v1beta2 conditions and worker replica counts.
+//
+// The Cluster object has conditions like Available, ScalingUp, ScalingDown,
+// Deleting, Paused, WorkersAvailable, WorkerMachinesReady, ControlPlaneAvailable,
+// ControlPlaneInitialized, etc. Worker replica counts are under status.workers.*.
+//
+// Priority order (first match wins):
+//  1. Deleting=True                                                           -> state="deleting", transitioning=true
+//  2. Paused=True                                                             -> state="paused", transitioning=true
+//  3. ScalingDown=True OR status.workers.replicas > status.workers.desiredReplicas -> state="updating", transitioning=true
+//  4. ScalingUp=True OR status.workers.desiredReplicas > status.workers.readyReplicas -> state="updating", transitioning=true
+//  5. Available=False                                                         -> state="updating", transitioning=true
+//  6. Available=True (or any other case)                                      -> pass through (no state set)
+func checkCAPIClusterTransitioning(obj data.Object, conditions []Condition, summary Summary) Summary {
+	// Read worker replica counts from status.workers.*.
+	desiredReplicas, desiredFound, _ := nestedInt64(obj, "status", "workers", "desiredReplicas")
+	workersReplicas, workersFound, _ := nestedInt64(obj, "status", "workers", "replicas")
+	readyReplicas, readyFound, _ := nestedInt64(obj, "status", "workers", "readyReplicas")
+
+	var scalingUp *Condition
+	var scalingDown *Condition
+	var available *Condition
+
+	for i := range conditions {
+		c := conditions[i]
+		typ := c.Type()
+
+		// Priority 1 & 2: Deleting and Paused take absolute priority.
+		if typ == "Deleting" && c.Status() == "True" {
+			summary.State = "deleting"
+			summary.Transitioning = true
+			if msg := c.Message(); msg != "" {
+				if strings.HasPrefix(msg, "* MachineDeployments") {
+					msg = "waiting for workers deletion"
+				}
+				summary.Message = append(summary.Message, msg)
+			}
+			return summary
+		}
+		if typ == "Paused" && c.Status() == "True" {
+			summary.State = "paused"
+			summary.Transitioning = true
+			return summary
+		}
+
+		switch typ {
+		case "ScalingUp":
+			scalingUp = &conditions[i]
+		case "ScalingDown":
+			scalingDown = &conditions[i]
+		case "Available":
+			available = &conditions[i]
+		}
+	}
+
+	// Priority 3: Scaling down — detected by condition OR replica count mismatch.
+	scalingDownByCondition := scalingDown != nil && scalingDown.Status() == "True"
+	scalingDownByReplicas := desiredFound && workersFound && workersReplicas > desiredReplicas
+	if scalingDownByCondition || scalingDownByReplicas {
+		summary.State = "updating"
+		summary.Transitioning = true
+		if desiredFound && workersFound {
+			summary.Message = append(summary.Message,
+				fmt.Sprintf("Scaling down from %d to %d machines", workersReplicas, desiredReplicas))
+		}
+		return summary
+	}
+
+	// Priority 4: Scaling up — detected by condition OR desired > readyReplicas.
+	scalingUpByCondition := scalingUp != nil && scalingUp.Status() == "True"
+	scalingUpByReplicas := desiredFound && readyFound && desiredReplicas > readyReplicas
+	if scalingUpByCondition || scalingUpByReplicas {
+		summary.State = "updating"
+		summary.Transitioning = true
+		if desiredFound && readyFound {
+			summary.Message = append(summary.Message,
+				fmt.Sprintf("Scaling up from %d to %d machines", readyReplicas, desiredReplicas))
+		}
+		return summary
+	}
+
+	// Priority 5: Available=False — the cluster is not yet available.
+	if available != nil {
+		switch available.Status() {
+		case "False":
+			summary.Transitioning = true
+			summary.State = "updating"
+			// Parse the first bullet line to determine the state.
+			detail, prefix := parseReadyFirstBullet(available.Message())
+			switch prefix {
+			case "RemoteConnectionProbe":
+				summary.Message = append(summary.Message, "establishing connection to control plane")
+			case "ControlPlaneAvailable":
+				summary.Message = append(summary.Message, "Waiting for control plane to be available")
+			case "MachineDeployment":
+				summary.Message = append(summary.Message, "Waiting for workers to be available")
+			default:
+				// If the first bullet doesn't match known patterns, pass through.
+				if detail != "" {
+					summary.Message = append(summary.Message, detail)
+				}
+			}
+
+		case "Unknown":
+			summary.Error = true
+			summary.State = "unavailable"
+			summary.Message = append(summary.Message, available.Message())
+		}
+		// Ready=True: pass through, let downstream summarizers handle it.
+	}
+
+	// Priority 6: Available=True or no conditions — pass through.
+	return summary
+}
+
+func checkGenericTransitioning(_ data.Object, conditions []Condition, summary Summary) Summary {
 	for _, c := range conditions {
 		newState, ok := TransitioningUnknown[c.Type()]
 		if !ok {
@@ -592,4 +925,115 @@ func checkApplyOwned(obj data.Object, conditions []Condition, summary Summary) S
 	summary.Relationships = append(summary.Relationships, rel)
 
 	return summary
+}
+
+// isCAPIMachine returns true if the object is a CAPI Machine (cluster.x-k8s.io/*/Machine).
+func isCAPIMachine(obj data.Object) bool {
+	return strings.HasPrefix(obj.String("apiVersion"), "cluster.x-k8s.io/") &&
+		obj.String("kind") == "Machine"
+}
+
+// isCAPIMachineSet returns true if the object is a CAPI MachineSet (cluster.x-k8s.io/*/MachineSet).
+func isCAPIMachineSet(obj data.Object) bool {
+	return strings.HasPrefix(obj.String("apiVersion"), "cluster.x-k8s.io/") &&
+		obj.String("kind") == "MachineSet"
+}
+
+// isCAPIMachineDeployment returns true if the object is a CAPI MachineDeployment (cluster.x-k8s.io/*/MachineDeployment).
+func isCAPIMachineDeployment(obj data.Object) bool {
+	return strings.HasPrefix(obj.String("apiVersion"), "cluster.x-k8s.io/") &&
+		obj.String("kind") == "MachineDeployment"
+}
+
+// isCAPICluster returns true if the object is a CAPI Cluster (cluster.x-k8s.io/*/Cluster).
+func isCAPICluster(obj data.Object) bool {
+	return strings.HasPrefix(obj.String("apiVersion"), "cluster.x-k8s.io/") &&
+		obj.String("kind") == "Cluster"
+}
+
+// parseReadyFirstBullet parses the first bullet line from a Ready condition
+// message. The Ready condition message format is:
+//
+//	\* <ConditionType>: <detail message>
+//	\* <ConditionType>: <detail message>
+//
+// or with nested sub-bullets when the top-level detail is empty:
+//
+//	\* <ConditionType>:
+//	  \* <SubCondition>: <detail message>
+//
+// Multiple lines are separated by newlines. This function returns:
+//   - detail: the stripped detail text (without "* " prefix and "ConditionType: "
+//     prefix). When the top-level bullet has no inline detail, the detail from
+//     the first indented sub-bullet is returned instead.
+//   - prefix: the condition type name from the first bullet (e.g., "InfrastructureReady")
+//
+// if the message is empty, then the function returns empty strings for both detail and prefix.
+// if the message does not match the expected format, then the function returns the message
+// as the detail and an empty string as the prefix.
+func parseReadyFirstBullet(message string) (detail, prefix string) {
+	if message == "" {
+		return "", ""
+	}
+
+	lines := strings.Split(message, "\n")
+
+	// Parse the first line.
+	firstLine := strings.TrimPrefix(lines[0], "* ")
+
+	// Split on ": " to separate condition type from detail.
+	colonIdx := strings.Index(firstLine, ": ")
+	if colonIdx < 0 {
+		// No ": " separator. Check if the line ends with ":" (empty detail
+		// with sub-bullets on subsequent lines).
+		if strings.HasSuffix(firstLine, ":") {
+			prefix = strings.TrimSuffix(firstLine, ":")
+		} else {
+			return firstLine, ""
+		}
+	} else {
+		prefix = firstLine[:colonIdx]
+		detail = firstLine[colonIdx+2:]
+	}
+
+	// If the top-level bullet has inline detail, return it.
+	if detail != "" {
+		return detail, prefix
+	}
+
+	// The top-level bullet has no inline detail (e.g., "* NodeHealthy:").
+	// Look for indented sub-bullets to extract the detail from.
+	for _, line := range lines[1:] {
+		trimmed := strings.TrimSpace(line)
+		if !strings.HasPrefix(trimmed, "* ") {
+			continue
+		}
+		// Found a sub-bullet: "* SubCondition: detail message"
+		subContent := strings.TrimPrefix(trimmed, "* ")
+		subColonIdx := strings.Index(subContent, ": ")
+		if subColonIdx >= 0 {
+			detail = subContent[subColonIdx+2:]
+		} else {
+			detail = subContent
+		}
+		break // Only use the first sub-bullet.
+	}
+
+	return detail, prefix
+}
+
+// nestedInt64 retrieves a nested numeric field from an unstructured object and
+// returns it as int64. Unlike unstructured.NestedInt64, which requires the value
+// to be exactly int64, this function also handles float64 (produced by JSON/YAML
+// decoders), json.Number, and string representations of integers.
+func nestedInt64(obj data.Object, fields ...string) (int64, bool, error) {
+	val, found, err := unstructured.NestedFieldNoCopy(obj, fields...)
+	if !found || err != nil {
+		return 0, found, err
+	}
+	n, err := convert.ToNumber(val)
+	if err != nil {
+		return 0, false, err
+	}
+	return n, true, nil
 }

--- a/pkg/summary/summarizers.go
+++ b/pkg/summary/summarizers.go
@@ -68,8 +68,8 @@ var (
 		"AbleToScale":                 "pending",
 		"RunCompleted":                "running",
 		"Processed":                   "processed",
-		// "NodeHealthy":                 reason, // CAPI Machine
-		// "NodeReady":                   reason, // CAPI Machine
+		"NodeHealthy":                 reason, // CAPI Machine
+		"NodeReady":                   reason, // CAPI Machine
 	}
 
 	// For given GVK, This condition Type and this Status, indicates an error or not
@@ -108,12 +108,12 @@ var (
 	// False == transitioning
 	// Unknown == error
 	TransitioningFalse = map[string]string{
-		"Completed": "activating",
-		"Ready":     "unavailable",
-		"Available": "updating",
-		// "BootstrapConfigReady": reason,     // CAPI Machine
-		// "InfrastructureReady":  reason,     // CAPI Machine
-		// "MachinesReady":        "updating", // CAPI MachineDeployment, MachineSet
+		"Completed":            "activating",
+		"Ready":                "unavailable",
+		"Available":            "updating",
+		"BootstrapConfigReady": reason,     // CAPI Machine
+		"InfrastructureReady":  reason,     // CAPI Machine
+		"MachinesReady":        "updating", // CAPI MachineDeployment, MachineSet
 	}
 
 	// True == transitioning
@@ -121,10 +121,10 @@ var (
 	// Unknown == error
 	TransitioningTrue = map[string]string{
 		"Reconciling": "reconciling",
-		// "ScalingUp":   reason, // CAPI Cluster, MachineDeployment, MachineSet
-		// "ScalingDown": reason, // CAPI Cluster, MachineDeployment, MachineSet
-		// "Deleting":    reason, // CAPI Cluster, MachineDeployment, MachineSet, Machine
-		// "Paused":      reason, // CAPI Cluster, MachineDeployment, MachineSet, Machine
+		"ScalingUp":   reason, // CAPI Cluster, MachineDeployment, MachineSet
+		"ScalingDown": reason, // CAPI Cluster, MachineDeployment, MachineSet
+		"Deleting":    reason, // CAPI Cluster, MachineDeployment, MachineSet, Machine
+		"Paused":      reason, // CAPI Cluster, MachineDeployment, MachineSet, Machine
 	}
 
 	Summarizers          []Summarizer
@@ -136,7 +136,7 @@ type Summarizer func(obj data.Object, conditions []Condition, summary Summary) S
 func init() {
 	ConditionSummarizers = []Summarizer{
 		checkErrors,
-		checkTransitioning,
+		checkGenericTransitioning,
 		checkRemoving,
 		checkCattleReady,
 	}
@@ -449,7 +449,7 @@ func checkCAPIMachineTransitioning(conditions []Condition, summary Summary) Summ
 		switch ready.Status() {
 		case "False":
 			// Parse the first bullet line to determine the state.
-			detail, prefix := parseReadyFirstBullet(ready.Message())
+			detail, prefix := parseMessage(ready.Message())
 			switch prefix {
 			case "BootstrapConfigReady":
 				summary.Transitioning = true
@@ -476,7 +476,7 @@ func checkCAPIMachineTransitioning(conditions []Condition, summary Summary) Summ
 		case "Unknown":
 			summary.Transitioning = true
 			summary.State = "reconciling"
-			detail, prefix := parseReadyFirstBullet(ready.Message())
+			detail, prefix := parseMessage(ready.Message())
 			if prefix == "NodeHealthy" {
 				if strings.HasSuffix(detail, "to report spec.providerID") {
 					detail = ""
@@ -664,7 +664,7 @@ func checkCAPIClusterTransitioning(obj data.Object, conditions []Condition, summ
 			summary.Transitioning = true
 			summary.State = "updating"
 			// Parse the first bullet line to determine the state.
-			detail, prefix := parseReadyFirstBullet(available.Message())
+			detail, prefix := parseMessage(available.Message())
 			switch prefix {
 			case "RemoteConnectionProbe":
 				summary.Message = append(summary.Message, "establishing connection to control plane")
@@ -698,6 +698,10 @@ func checkGenericTransitioning(_ data.Object, conditions []Condition, summary Su
 			continue
 		}
 
+		if newState == reason {
+			newState = c.Reason()
+		}
+
 		if c.Status() == "False" {
 			summary.Error = true
 			summary.State = newState
@@ -717,6 +721,11 @@ func checkGenericTransitioning(_ data.Object, conditions []Condition, summary Su
 		if !ok {
 			continue
 		}
+
+		if newState == reason {
+			newState = c.Reason()
+		}
+
 		if c.Status() == "True" {
 			summary.Transitioning = true
 			summary.State = newState
@@ -951,8 +960,8 @@ func isCAPICluster(obj data.Object) bool {
 		obj.String("kind") == "Cluster"
 }
 
-// parseReadyFirstBullet parses the first bullet line from a Ready condition
-// message. The Ready condition message format is:
+// parseMessage parses the first bullet line from a condition message.
+// The condition message format is:
 //
 //	\* <ConditionType>: <detail message>
 //	\* <ConditionType>: <detail message>
@@ -963,15 +972,11 @@ func isCAPICluster(obj data.Object) bool {
 //	  \* <SubCondition>: <detail message>
 //
 // Multiple lines are separated by newlines. This function returns:
-//   - detail: the stripped detail text (without "* " prefix and "ConditionType: "
-//     prefix). When the top-level bullet has no inline detail, the detail from
+//   - detail: the stripped detail text (without "* ConditionType: " prefix).
+//     When the top-level bullet has no inline detail, the detail from
 //     the first indented sub-bullet is returned instead.
-//   - prefix: the condition type name from the first bullet (e.g., "InfrastructureReady")
-//
-// if the message is empty, then the function returns empty strings for both detail and prefix.
-// if the message does not match the expected format, then the function returns the message
-// as the detail and an empty string as the prefix.
-func parseReadyFirstBullet(message string) (detail, prefix string) {
+//   - prefix: the condition type name from the top-level bullet.
+func parseMessage(message string) (detail, prefix string) {
 	if message == "" {
 		return "", ""
 	}

--- a/pkg/summary/summarizers.go
+++ b/pkg/summary/summarizers.go
@@ -53,7 +53,7 @@ var (
 		"Pending":                     "pending",
 		"PodScheduled":                "scheduling",
 		"Provisioned":                 "provisioning",
-		"Reconciled":                  "reconciling",
+		"Reconciled":                  "reconciling", // CAPI Machine, RKEControlPlane
 		"Refreshed":                   "refreshed",
 		"Registered":                  "registering",
 		"Removed":                     "removing",
@@ -67,6 +67,8 @@ var (
 		"AbleToScale":                 "pending",
 		"RunCompleted":                "running",
 		"Processed":                   "processed",
+		"NodeHealthy":                 reason, // CAPI Machine
+		"NodeReady":                   reason, // CAPI Machine
 	}
 
 	// For given GVK, This condition Type and this Status, indicates an error or not
@@ -105,12 +107,12 @@ var (
 	// False == transitioning
 	// Unknown == error
 	TransitioningFalse = map[string]string{
-		"Completed":           "activating",
-		"Ready":               "unavailable",
-		"Available":           "updating",
-		"BootstrapReady":      reason,
-		"InfrastructureReady": reason,
-		"NodeHealthy":         reason,
+		"Completed":            "activating",
+		"Ready":                "unavailable",
+		"Available":            "updating",
+		"BootstrapConfigReady": reason,     // CAPI Machine
+		"InfrastructureReady":  reason,     // CAPI Machine
+		"MachinesReady":        "updating", // CAPI MachineDeployment, MachineSet
 	}
 
 	// True == transitioning
@@ -118,6 +120,10 @@ var (
 	// Unknown == error
 	TransitioningTrue = map[string]string{
 		"Reconciling": "reconciling",
+		"ScalingUp":   reason, // CAPI Cluster, MachineDeployment, MachineSet
+		"ScalingDown": reason, // CAPI Cluster, MachineDeployment, MachineSet
+		"Deleting":    reason, // CAPI Cluster, MachineDeployment, MachineSet, Machine
+		"Paused":      reason, // CAPI Cluster, MachineDeployment, MachineSet, Machine
 	}
 
 	Summarizers          []Summarizer


### PR DESCRIPTION
**Issue** 

- https://github.com/rancher/rancher/issues/53612

This PR adds CAPI v1beta2-aware summary/transitioning logic for Cluster API resources and updates condition normalization to use standard `status.conditions` rather than deprecated v1beta1 condition blocks. 

Rancher UI displays a state and an optional message for CAPI resources based on the summary. 
Overall, these changes should yield clearer, more accurate states and messages.  
The changes were reviewed and approved by the UI team. 
For a detailed comparison between the old and new summary, please check: [Changes to CAPI Objects’ State in UI](https://docs.google.com/document/d/1OCtDpj3CpVUQdTAxCzCEJVxYoNwF7YvQAr1m6zpgE3o/edit?usp=sharing)

**Changes**:

- Add CAPI-specific transitioning summarizers for CAPI Machine, MachineSet/MachineDeployment, and Cluster, including parsing v1beta2 aggregate condition messages.
- Remove deprecated CAPI v1beta1 condition selection/normalization and adjust condition-related tests accordingly.
- Add focused unit tests covering the new CAPI transitioning behavior and helper utilities.
- Update the transitioning maps to match the new behavior of CAPI conditions, which is still needed for the NormalizeConditions function that summarizes one condition each time. 



**Testing**

The changes were validated in the local development environment, where Rancher was modified to use the PR's branch to import wrangler in go mod.


**Next Steps**

After merging this PR, cut a new tag, and bump the rancher/wrangler package version in rancher/rancher 

