### PR TITLE
pin mockgen to commit SHA instead of mutable tag

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -23,7 +23,8 @@ jobs:
       # https://github.com/actions/checkout/releases/tag/v4.1.1
       uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
     - name : Install mockgen
-      run: go install -v -x go.uber.org/mock/mockgen@v0.6.0
+      # renovate: datasource=github-releases depName=uber-go/mock
+      run: go install go.uber.org/mock/mockgen@2d1c58167e30f380cf78e44a43b100a14767e817
     - name : Run CI
       run: bash scripts/ci
   golangci:

--- a/scripts/ci
+++ b/scripts/ci
@@ -6,7 +6,7 @@ echo "Validating"
 
 if [[ -z $(type -p "mockgen") ]]; then
     echo "'mockgen': executable file not found in \$PATH. mockgen is needed to compelete code generation."
-    echo "Install mockgen with 'go install go.uber.org/mock/mockgen@v0.6.0'"
+    echo "Install mockgen with 'go install go.uber.org/mock/mockgen@2d1c58167e30f380cf78e44a43b100a14767e817'"
     exit 1
 fi
 


### PR DESCRIPTION
Pin go install for mockgen from the v0.6.0 tag to its underlying commit SHA.