### PR TITLE
Ignore the 'x of y completed' message in state message

### DIFF
--- a/pkg/summary/capi_machine_test.go
+++ b/pkg/summary/capi_machine_test.go
@@ -352,6 +352,20 @@ func TestCheckCAPIMachineTransitioning(t *testing.T) {
 			// Detail is suppressed — no messages expected.
 		},
 		{
+			name: "Ready=False, InfrastructureReady detail suppressed when matching 'X of Y completed' pattern",
+			conditions: []Condition{
+				NewCondition("Ready", "False", "NotReady",
+					"* InfrastructureReady: 2 of 3 completed\n"+
+						"* NodeHealthy: Last successful probe at 2026-04-24T10:00:22Z"),
+				NewCondition("Paused", "False", "NotPaused", ""),
+				NewCondition("Deleting", "False", "NotDeleting", ""),
+			},
+			expectedState:   "waitingfornoderef",
+			expectedTransit: true,
+			expectedError:   false,
+			// "2 of 3 completed" is suppressed — no messages expected.
+		},
+		{
 			name: "Ready=False with empty message → pass through",
 			conditions: []Condition{
 				NewCondition("Ready", "False", "NotReady", ""),

--- a/pkg/summary/summarizers.go
+++ b/pkg/summary/summarizers.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"os"
+	"regexp"
 	"strings"
 	"time"
 
@@ -26,6 +27,10 @@ const (
 )
 
 var (
+	// stepCounterMessagePattern matches "X of Y completed" messages from CAPI infrastructure providers.
+	// These are from the deprecated v1beta1 conditions merge strategy and are not useful to end users.
+	stepCounterMessagePattern = regexp.MustCompile(`^\d+ of \d+ completed$`)
+
 	// True ==
 	// False == error
 	// Unknown == transitioning
@@ -464,6 +469,9 @@ func checkCAPIMachineTransitioning(conditions []Condition, summary Summary) Summ
 				summary.Transitioning = true
 				summary.State = "waitingfornoderef"
 				if strings.HasSuffix(detail, "status.initialization.provisioned is false") {
+					detail = ""
+				}
+				if stepCounterMessagePattern.MatchString(detail) {
 					detail = ""
 				}
 				if detail != "" {

--- a/pkg/summary/summarizers.go
+++ b/pkg/summary/summarizers.go
@@ -792,6 +792,12 @@ func checkGenericTransitioning(_ data.Object, conditions []Condition, summary Su
 		if c.Type() == "Ready" && c.Status() == "False" {
 			ready = false
 			readyMessage = c.Message()
+
+			// ignore the message that is in the form of "x of y completed",
+			// seen on AWSMachine.infrastructure.cluster.x-k8s.io/v1beta2
+			if stepCounterMessagePattern.MatchString(c.Message()) {
+				readyMessage = ""
+			}
 			continue
 		}
 		newState, ok := TransitioningFalse[c.Type()]


### PR DESCRIPTION
**Problem**
 
- https://github.com/rancher/rancher/issues/54629

We’ve received reports of the `"x of y completed"` message appearing on the CAPI Machine in the UI. I was not able to reproduce this locally, but the behavior is theoretically possible.

The message originates from the AWSMachine’s deprecated v1beta1 step counter (via `WithStepCounter()`). It is then propagated unchanged to the CAPI Machine’s `InfrastructureReady` condition, and ultimately surfaced in the Machine’s `Ready` condition summary.

This message is still commonly observed on AWSMachine objects in the UI. However, its appearance on CAPI Machine is unexpected and confusing, as it has not historically been exposed at that level.

**Fix**

Filter out messages matching the `"x of y completed"` pattern at the relevant propagation points to prevent them from surfacing in higher-level conditions.

**Validation**

The fix has been validated locally.


