### PR TITLE
summary/client: stop event-forward goroutine on ctx.Done

### DIFF
--- a/pkg/summary/client/simple.go
+++ b/pkg/summary/client/simple.go
@@ -112,7 +112,11 @@ func (c *summaryResourceClient) Watch(ctx context.Context, opts metav1.ListOptio
 			if _, ok := event.Object.(*metav1.Status); !ok {
 				event.Object = summary.SummarizedWithOptions(event.Object, generateSummarizeOpts(c.options.Schema))
 			}
-			eventChan <- event
+			select {
+			case eventChan <- event:
+			case <-ctx.Done():
+				return
+			}
 		}
 	}()
 


### PR DESCRIPTION
Closes #652. The unbuffered chan send blocks forever once the consumer stops reading; select on ctx.Done() to drain.