### PR TITLE
misc(summaryInformer): include original type in error messages

### DIFF
--- a/pkg/summary/informer/informer.go
+++ b/pkg/summary/informer/informer.go
@@ -18,6 +18,7 @@ package informer
 
 import (
 	"context"
+	"fmt"
 	"sync"
 	"time"
 
@@ -166,13 +167,17 @@ func NewFilteredSummaryInformer(client client.Interface, gvr schema.GroupVersion
 			return client.Resource(gvr).Namespace(namespace).Watch(context.TODO(), options)
 		},
 	}
+	exampleObject := new(summary.SummarizedObject)
 	return &summaryInformer{
 		gvr: gvr,
-		informer: cache.NewSharedIndexInformer(
+		informer: cache.NewSharedIndexInformerWithOptions(
 			toListWatcherWithWatchListSemantics(lw, client),
-			&summary.SummarizedObject{},
-			resyncPeriod,
-			indexers,
+			exampleObject,
+			cache.SharedIndexInformerOptions{
+				ResyncPeriod:      resyncPeriod,
+				Indexers:          indexers,
+				ObjectDescription: fmt.Sprintf("%T(%s)", exampleObject, gvr),
+			},
 		),
 	}
 }

--- a/pkg/summary/informer/informer_test.go
+++ b/pkg/summary/informer/informer_test.go
@@ -2,14 +2,21 @@ package informer
 
 import (
 	"context"
+	"fmt"
 	"testing"
 	"time"
 
 	"github.com/rancher/wrangler/v3/pkg/summary"
 	"github.com/rancher/wrangler/v3/pkg/summary/client"
+
+	"github.com/stretchr/testify/assert"
+	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apimachinery/pkg/watch"
+	"k8s.io/client-go/dynamic/fake"
+	k8stesting "k8s.io/client-go/testing"
 	"k8s.io/client-go/tools/cache"
 )
 
@@ -244,4 +251,33 @@ func TestNewFilteredSummaryInformerWithOptions_WatchListSupport(t *testing.T) {
 			}
 		})
 	}
+}
+
+func TestSummaryInformer_typeDescription(t *testing.T) {
+	ctx, cancel := context.WithTimeout(t.Context(), 2*time.Second)
+	defer cancel()
+
+	scheme := runtime.NewScheme()
+	assert.NoError(t, corev1.AddToScheme(scheme))
+	gvr := corev1.SchemeGroupVersion.WithResource("pods")
+
+	dynamicClient := fake.NewSimpleDynamicClient(scheme)
+	dynamicClient.PrependWatchReactor("*", func(k8stesting.Action) (bool, watch.Interface, error) {
+		return true, nil, fmt.Errorf("fake error!")
+	})
+	informer := NewFilteredSummaryInformer(client.NewForExtendedDynamicClient(dynamicClient), gvr, "", 0, cache.Indexers{}, nil)
+
+	var gotError bool
+	assert.NoError(t, informer.Informer().SetWatchErrorHandler(func(r *cache.Reflector, err error) {
+		// TypeDescription is used by the DefaultWatchErrorHandler
+		assert.Contains(t, r.TypeDescription(), "*summary.SummarizedObject(/v1, Resource=pods)")
+		gotError = true
+		cancel()
+	}))
+
+	go informer.Informer().RunWithContext(ctx)
+	<-ctx.Done()
+
+	assert.True(t, gotError)
+
 }


### PR DESCRIPTION
When Kubernetes cache reflectors experience a failure, they will normally log an error message, trying to infer the kind/type that the informer is configured for. Normally, it will fallback to the name of the struct used as example object at the moment of initialization, but it it's possible to configure a specific type description.
When using "FilteredSummaryInformers" (summarizing wrappers around different kinds, steve creates many of them), the example object is always a `*summary.SummarizedObject`, which makes all error messages look the same, e.g.:
```
"E0413 22:16:18.708507 56 reflector.go:205] "Failed to watch" err="failed to list *summary.SummarizedObject: the server could not find the requested resource" logger="UnhandledError" reflector="/root/.cache/go/modcache/k8s.io/client-go@v0.34.2/tools/cache/reflector.go:290" type="*summary.SummarizedObject" "
```
(produced from the [`DefaultWatchErrorHandler`](https://github.com/kubernetes/client-go/blob/v0.36.0/tools/cache/reflector.go#L227))

This PR just configures the type description to provide visibility on the original kind being watched.