### PR TITLE
misc(summaryInformer): make ListWatcher context-aware

### DIFF
--- a/pkg/summary/informer/informer.go
+++ b/pkg/summary/informer/informer.go
@@ -126,17 +126,17 @@ func NewFilteredSummaryInformerWithOptions(
 	tweakListOptions TweakListOptionsFunc,
 ) informers.GenericInformer {
 	lw := &cache.ListWatch{
-		ListFunc: func(options metav1.ListOptions) (runtime.Object, error) {
+		ListWithContextFunc: func(ctx context.Context, options metav1.ListOptions) (runtime.Object, error) {
 			if tweakListOptions != nil {
 				tweakListOptions(&options)
 			}
-			return client.ResourceWithOptions(gvr, opts).Namespace(namespace).List(context.TODO(), options)
+			return client.ResourceWithOptions(gvr, opts).Namespace(namespace).List(ctx, options)
 		},
-		WatchFunc: func(options metav1.ListOptions) (watch.Interface, error) {
+		WatchFuncWithContext: func(ctx context.Context, options metav1.ListOptions) (watch.Interface, error) {
 			if tweakListOptions != nil {
 				tweakListOptions(&options)
 			}
-			return client.ResourceWithOptions(gvr, opts).Namespace(namespace).Watch(context.TODO(), options)
+			return client.ResourceWithOptions(gvr, opts).Namespace(namespace).Watch(ctx, options)
 		},
 	}
 	return &summaryInformer{

--- a/pkg/summary/informer/informer.go
+++ b/pkg/summary/informer/informer.go
@@ -153,17 +153,17 @@ func NewFilteredSummaryInformerWithOptions(
 // NewFilteredSummaryInformer constructs a new informer for a summary type.
 func NewFilteredSummaryInformer(client client.Interface, gvr schema.GroupVersionResource, namespace string, resyncPeriod time.Duration, indexers cache.Indexers, tweakListOptions TweakListOptionsFunc) informers.GenericInformer {
 	lw := &cache.ListWatch{
-		ListFunc: func(options metav1.ListOptions) (runtime.Object, error) {
+		ListWithContextFunc: func(ctx context.Context, options metav1.ListOptions) (runtime.Object, error) {
 			if tweakListOptions != nil {
 				tweakListOptions(&options)
 			}
-			return client.Resource(gvr).Namespace(namespace).List(context.TODO(), options)
+			return client.Resource(gvr).Namespace(namespace).List(ctx, options)
 		},
-		WatchFunc: func(options metav1.ListOptions) (watch.Interface, error) {
+		WatchFuncWithContext: func(ctx context.Context, options metav1.ListOptions) (watch.Interface, error) {
 			if tweakListOptions != nil {
 				tweakListOptions(&options)
 			}
-			return client.Resource(gvr).Namespace(namespace).Watch(context.TODO(), options)
+			return client.Resource(gvr).Namespace(namespace).Watch(ctx, options)
 		},
 	}
 	return &summaryInformer{


### PR DESCRIPTION
`ListFunc` and `WatchFunc` are marked as deprecated (`context.TODO()` was already a hint), in favor of context-aware equivalents.