### PR TITLE
fix(summary/informer): use informer context in List and Watch calls

### DIFF
--- a/pkg/summary/informer/informer.go
+++ b/pkg/summary/informer/informer.go
@@ -126,17 +126,17 @@ func NewFilteredSummaryInformerWithOptions(
 	tweakListOptions TweakListOptionsFunc,
 ) informers.GenericInformer {
 	lw := &cache.ListWatch{
-		ListFunc: func(options metav1.ListOptions) (runtime.Object, error) {
+		ListWithContextFunc: func(ctx context.Context, options metav1.ListOptions) (runtime.Object, error) {
 			if tweakListOptions != nil {
 				tweakListOptions(&options)
 			}
-			return client.ResourceWithOptions(gvr, opts).Namespace(namespace).List(context.TODO(), options)
+			return client.ResourceWithOptions(gvr, opts).Namespace(namespace).List(ctx, options)
 		},
-		WatchFunc: func(options metav1.ListOptions) (watch.Interface, error) {
+		WatchFuncWithContext: func(ctx context.Context, options metav1.ListOptions) (watch.Interface, error) {
 			if tweakListOptions != nil {
 				tweakListOptions(&options)
 			}
-			return client.ResourceWithOptions(gvr, opts).Namespace(namespace).Watch(context.TODO(), options)
+			return client.ResourceWithOptions(gvr, opts).Namespace(namespace).Watch(ctx, options)
 		},
 	}
 	return &summaryInformer{
@@ -153,17 +153,17 @@ func NewFilteredSummaryInformerWithOptions(
 // NewFilteredSummaryInformer constructs a new informer for a summary type.
 func NewFilteredSummaryInformer(client client.Interface, gvr schema.GroupVersionResource, namespace string, resyncPeriod time.Duration, indexers cache.Indexers, tweakListOptions TweakListOptionsFunc) informers.GenericInformer {
 	lw := &cache.ListWatch{
-		ListFunc: func(options metav1.ListOptions) (runtime.Object, error) {
+		ListWithContextFunc: func(ctx context.Context, options metav1.ListOptions) (runtime.Object, error) {
 			if tweakListOptions != nil {
 				tweakListOptions(&options)
 			}
-			return client.Resource(gvr).Namespace(namespace).List(context.TODO(), options)
+			return client.Resource(gvr).Namespace(namespace).List(ctx, options)
 		},
-		WatchFunc: func(options metav1.ListOptions) (watch.Interface, error) {
+		WatchFuncWithContext: func(ctx context.Context, options metav1.ListOptions) (watch.Interface, error) {
 			if tweakListOptions != nil {
 				tweakListOptions(&options)
 			}
-			return client.Resource(gvr).Namespace(namespace).Watch(context.TODO(), options)
+			return client.Resource(gvr).Namespace(namespace).Watch(ctx, options)
 		},
 	}
 	return &summaryInformer{

--- a/pkg/summary/informer/informer_test.go
+++ b/pkg/summary/informer/informer_test.go
@@ -156,6 +156,174 @@ func TestNewFilteredSummaryInformer_WatchListSupport(t *testing.T) {
 	}
 }
 
+// blockingClient blocks List or Watch until the informer's context is cancelled.
+// IsWatchListSemanticsUnSupported returns true so the traditional List→Watch path
+// is exercised, making both ListWithContextFunc and WatchFuncWithContext reachable independently.
+type blockingClient struct {
+	listCtxCh  chan context.Context
+	watchCtxCh chan context.Context
+}
+
+var _ client.ExtendedInterface = (*blockingClient)(nil)
+
+func (m *blockingClient) IsWatchListSemanticsUnSupported() bool { return true }
+func (m *blockingClient) Resource(_ schema.GroupVersionResource) client.NamespaceableResourceInterface {
+	return m
+}
+func (m *blockingClient) ResourceWithOptions(_ schema.GroupVersionResource, _ *client.Options) client.NamespaceableResourceInterface {
+	return m
+}
+func (m *blockingClient) Namespace(string) client.ResourceInterface { return m }
+
+func (m *blockingClient) List(ctx context.Context, _ metav1.ListOptions) (*summary.SummarizedObjectList, error) {
+	if m.listCtxCh != nil {
+		select {
+		case m.listCtxCh <- ctx:
+		default:
+		}
+		<-ctx.Done()
+		return nil, ctx.Err()
+	}
+	return &summary.SummarizedObjectList{ListMeta: metav1.ListMeta{ResourceVersion: "1"}}, nil
+}
+
+func (m *blockingClient) Watch(ctx context.Context, _ metav1.ListOptions) (watch.Interface, error) {
+	if m.watchCtxCh != nil {
+		select {
+		case m.watchCtxCh <- ctx:
+		default:
+		}
+		fw := watch.NewFake()
+		go func() { <-ctx.Done(); fw.Stop() }()
+		return fw, nil
+	}
+	return watch.NewFake(), nil
+}
+
+func TestNewFilteredSummaryInformer_ListUsesRunContext(t *testing.T) {
+	listCtxCh := make(chan context.Context, 1)
+	mc := &blockingClient{listCtxCh: listCtxCh}
+
+	gvr := schema.GroupVersionResource{Group: "test", Version: "v1", Resource: "tests"}
+	inf := NewFilteredSummaryInformer(mc, gvr, metav1.NamespaceAll, 0, cache.Indexers{}, nil)
+	stopCh := make(chan struct{})
+	go inf.Informer().Run(stopCh)
+
+	var listCtx context.Context
+	select {
+	case listCtx = <-listCtxCh:
+	case <-time.After(5 * time.Second):
+		t.Fatal("List was not called within timeout")
+	}
+
+	select {
+	case <-listCtx.Done():
+		t.Fatal("List context should not be cancelled before informer stops")
+	default:
+	}
+
+	close(stopCh)
+
+	select {
+	case <-listCtx.Done():
+	case <-time.After(5 * time.Second):
+		t.Fatal("List context was not cancelled after informer stopped")
+	}
+}
+
+func TestNewFilteredSummaryInformer_WatchUsesRunContext(t *testing.T) {
+	watchCtxCh := make(chan context.Context, 1)
+	mc := &blockingClient{watchCtxCh: watchCtxCh}
+
+	gvr := schema.GroupVersionResource{Group: "test", Version: "v1", Resource: "tests"}
+	inf := NewFilteredSummaryInformer(mc, gvr, metav1.NamespaceAll, 0, cache.Indexers{}, nil)
+	stopCh := make(chan struct{})
+	go inf.Informer().Run(stopCh)
+
+	var watchCtx context.Context
+	select {
+	case watchCtx = <-watchCtxCh:
+	case <-time.After(5 * time.Second):
+		t.Fatal("Watch was not called within timeout")
+	}
+
+	select {
+	case <-watchCtx.Done():
+		t.Fatal("Watch context should not be cancelled before informer stops")
+	default:
+	}
+
+	close(stopCh)
+
+	select {
+	case <-watchCtx.Done():
+	case <-time.After(5 * time.Second):
+		t.Fatal("Watch context was not cancelled after informer stopped")
+	}
+}
+
+func TestNewFilteredSummaryInformerWithOptions_ListUsesRunContext(t *testing.T) {
+	listCtxCh := make(chan context.Context, 1)
+	mc := &blockingClient{listCtxCh: listCtxCh}
+
+	gvr := schema.GroupVersionResource{Group: "test", Version: "v1", Resource: "tests"}
+	inf := NewFilteredSummaryInformerWithOptions(mc, gvr, nil, metav1.NamespaceAll, 0, cache.Indexers{}, nil)
+	stopCh := make(chan struct{})
+	go inf.Informer().Run(stopCh)
+
+	var listCtx context.Context
+	select {
+	case listCtx = <-listCtxCh:
+	case <-time.After(5 * time.Second):
+		t.Fatal("List was not called within timeout")
+	}
+
+	select {
+	case <-listCtx.Done():
+		t.Fatal("List context should not be cancelled before informer stops")
+	default:
+	}
+
+	close(stopCh)
+
+	select {
+	case <-listCtx.Done():
+	case <-time.After(5 * time.Second):
+		t.Fatal("List context was not cancelled after informer stopped")
+	}
+}
+
+func TestNewFilteredSummaryInformerWithOptions_WatchUsesRunContext(t *testing.T) {
+	watchCtxCh := make(chan context.Context, 1)
+	mc := &blockingClient{watchCtxCh: watchCtxCh}
+
+	gvr := schema.GroupVersionResource{Group: "test", Version: "v1", Resource: "tests"}
+	inf := NewFilteredSummaryInformerWithOptions(mc, gvr, nil, metav1.NamespaceAll, 0, cache.Indexers{}, nil)
+	stopCh := make(chan struct{})
+	go inf.Informer().Run(stopCh)
+
+	var watchCtx context.Context
+	select {
+	case watchCtx = <-watchCtxCh:
+	case <-time.After(5 * time.Second):
+		t.Fatal("Watch was not called within timeout")
+	}
+
+	select {
+	case <-watchCtx.Done():
+		t.Fatal("Watch context should not be cancelled before informer stops")
+	default:
+	}
+
+	close(stopCh)
+
+	select {
+	case <-watchCtx.Done():
+	case <-time.After(5 * time.Second):
+		t.Fatal("Watch context was not cancelled after informer stopped")
+	}
+}
+
 func TestNewFilteredSummaryInformerWithOptions_WatchListSupport(t *testing.T) {
 	gvr := schema.GroupVersionResource{Group: "test", Version: "v1", Resource: "tests"}
 	namespace := "default"


### PR DESCRIPTION
Partially Fixes rancher/rancher#55624

`NewFilteredSummaryInformer` and `NewFilteredSummaryInformerWithOptions` used
`context.TODO()` in their `ListFunc`/`WatchFunc` closures. When a watcher is
cancelled, the in-flight API request had no way to receive that cancellation
and would keep waiting on the full Kubernetes webhook timeout.

Replace `ListFunc`/`WatchFunc` with `ListWithContextFunc`/`WatchFuncWithContext`
and pass through the informer's run context so cancellation propagates correctly.


