### PR TITLE
[main] disable golang.org/x/* minor/major bumps on release branches

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -2,7 +2,7 @@
   "extends": [
     "github>rancher/renovate-config#release"
   ],
-  "baseBranchPatterns": [
+  "baseBranches": [
     "main",
     "release/v3.3",
     "release/v3.6",
@@ -32,8 +32,8 @@
       "enabled": false
     },
     {
-      "description": "Do not bump golang.org/x/tools minor/major on release branches - it tracks Go language releases and bumping it forces a go directive minor bump",
-      "matchPackageNames": ["golang.org/x/tools"],
+      "description": "Do not bump golang.org/x/* minor/major on release branches - unnecessary churn on stable branches; x/tools specifically can force a go directive minor bump",
+      "matchPackageNames": ["/^golang\\.org\\/x\\//"],
       "matchUpdateTypes": ["major", "minor"],
       "matchBaseBranches": ["/^release\\//"],
       "enabled": false


### PR DESCRIPTION
- Extends the existing `golang.org/x/tools` release-branch disable rule to cover all `golang.org/x/*` packages, preventing minor/major bumps (e.g. `x/sync`, `x/text`) from generating PRs on release branches
- Renames `baseBranchPatterns` → `baseBranches`