### PR TITLE
Make CABundle CA-chaining optional in needacert

### DIFF
--- a/pkg/needacert/needacert.go
+++ b/pkg/needacert/needacert.go
@@ -5,6 +5,7 @@ import (
 	"context"
 	"crypto/tls"
 	"crypto/x509"
+	"encoding/pem"
 	"fmt"
 	"strings"
 	"time"
@@ -31,6 +32,24 @@ import (
 var (
 	SecretAnnotation = "need-a-cert.cattle.io/secret-name"
 	DNSAnnotation    = "need-a-cert.cattle.io/dns-name"
+	// CABundleModeAnnotation lets an individual Service opt its webhooks/CRD
+	// conversion config into CABundleModeCAOnly. Any other value (including
+	// absent, the default) keeps the historical CABundleModeFullChain behavior.
+	// Scoped per-Service so one consumer can opt in without affecting any other
+	// consumer sharing the same needacert controller.
+	CABundleModeAnnotation = "need-a-cert.cattle.io/ca-bundle-mode"
+)
+
+const (
+	// CABundleModeFullChain is the default: CABundle is set to the full contents
+	// of the TLS secret's tls.crt entry, which is the leaf certificate followed
+	// by the CA certificate that signed it.
+	CABundleModeFullChain = "full-chain"
+	// CABundleModeCAOnly sets CABundle to just the CA certificate, omitting the
+	// leaf certificate. The leaf certificate isn't needed to validate trust and
+	// dropping it roughly halves CABundle's size, which matters when many
+	// webhooks share it: see https://github.com/rancher/turtles/issues/2452.
+	CABundleModeCAOnly = "ca-only"
 )
 
 const (
@@ -107,6 +126,41 @@ type handler struct {
 	crds               apiextcontrollers.CustomResourceDefinitionController
 }
 
+// caBundleFor returns the bytes that should populate a webhook/CRD ClientConfig's
+// CABundle field for the given service/secret pair. Only a service's
+// CABundleModeAnnotation set to CABundleModeCAOnly changes the result; anything
+// else (including a nil service) keeps the default full-chain behavior, so one
+// consumer can opt in without affecting any other consumer sharing the same
+// needacert handler.
+func caBundleFor(service *corev1.Service, secret *corev1.Secret) ([]byte, error) {
+	fullChain := secret.Data[corev1.TLSCertKey]
+	if service == nil || service.Annotations[CABundleModeAnnotation] != CABundleModeCAOnly {
+		return fullChain, nil
+	}
+	return caOnly(fullChain)
+}
+
+// caOnly takes a PEM blob containing a leaf certificate followed by the CA
+// certificate that signed it (the format produced by
+// cert.GenerateSelfSignedCertKey) and returns just the CA certificate, PEM
+// encoded.
+func caOnly(fullChainPEM []byte) ([]byte, error) {
+	certs, err := cert.ParseCertsPEM(fullChainPEM)
+	if err != nil {
+		return nil, fmt.Errorf("failed to parse certificate chain: %w", err)
+	}
+	if len(certs) == 0 {
+		return nil, fmt.Errorf("no certificates found in chain")
+	}
+
+	caCert := certs[len(certs)-1]
+	var buf bytes.Buffer
+	if err := pem.Encode(&buf, &pem.Block{Type: cert.CertificateBlockType, Bytes: caCert.Raw}); err != nil {
+		return nil, fmt.Errorf("failed to encode CA certificate: %w", err)
+	}
+	return buf.Bytes(), nil
+}
+
 func validatingWebhookServices(obj *adminregv1.ValidatingWebhookConfiguration) (result []string, _ error) {
 	for _, webhook := range obj.Webhooks {
 		if webhook.ClientConfig.Service != nil {
@@ -165,9 +219,13 @@ func (h *handler) OnMutationWebhookChange(key string, webhook *adminregv1.Mutati
 			continue
 		}
 
-		if !bytes.Equal(webhookConfig.ClientConfig.CABundle, secret.Data[corev1.TLSCertKey]) {
+		caBundle, err := caBundleFor(service, secret)
+		if err != nil {
+			return nil, err
+		}
+		if !bytes.Equal(webhookConfig.ClientConfig.CABundle, caBundle) {
 			webhook = webhook.DeepCopy()
-			webhook.Webhooks[i].ClientConfig.CABundle = secret.Data[corev1.TLSCertKey]
+			webhook.Webhooks[i].ClientConfig.CABundle = caBundle
 			needUpdate = true
 		}
 	}
@@ -209,9 +267,13 @@ func (h *handler) OnValidatingWebhookChange(key string, webhook *adminregv1.Vali
 			continue
 		}
 
-		if !bytes.Equal(webhookConfig.ClientConfig.CABundle, secret.Data[corev1.TLSCertKey]) {
+		caBundle, err := caBundleFor(service, secret)
+		if err != nil {
+			return nil, err
+		}
+		if !bytes.Equal(webhookConfig.ClientConfig.CABundle, caBundle) {
 			webhook = webhook.DeepCopy()
-			webhook.Webhooks[i].ClientConfig.CABundle = secret.Data[corev1.TLSCertKey]
+			webhook.Webhooks[i].ClientConfig.CABundle = caBundle
 			needUpdate = true
 		}
 	}
@@ -289,9 +351,13 @@ func (h *handler) OnCRDChange(key string, crd *apiextv1.CustomResourceDefinition
 		return crd, nil
 	}
 
-	if !bytes.Equal(crd.Spec.Conversion.Webhook.ClientConfig.CABundle, secret.Data[corev1.TLSCertKey]) {
+	caBundle, err := caBundleFor(service, secret)
+	if err != nil {
+		return nil, err
+	}
+	if !bytes.Equal(crd.Spec.Conversion.Webhook.ClientConfig.CABundle, caBundle) {
 		crd := crd.DeepCopy()
-		crd.Spec.Conversion.Webhook.ClientConfig.CABundle = secret.Data[corev1.TLSCertKey]
+		crd.Spec.Conversion.Webhook.ClientConfig.CABundle = caBundle
 		return h.crds.Update(crd)
 	}
 

--- a/pkg/needacert/needacert.go
+++ b/pkg/needacert/needacert.go
@@ -152,6 +152,11 @@ func caOnly(fullChainPEM []byte) ([]byte, error) {
 	if len(certs) == 0 {
 		return nil, fmt.Errorf("no certificates found in chain")
 	}
+	if len(certs) == 1 {
+		// Only one cert in the chain means it's already the CA (no leaf to
+		// strip), so return it unmodified instead of re-encoding.
+		return fullChainPEM, nil
+	}
 
 	caCert := certs[len(certs)-1]
 	var buf bytes.Buffer

--- a/pkg/needacert/needacert_test.go
+++ b/pkg/needacert/needacert_test.go
@@ -842,6 +842,297 @@ func TestHandler_Race_Stress(t *testing.T) {
 	}
 }
 
+func TestCAOnly(t *testing.T) {
+	fullChain, _, err := cert.GenerateSelfSignedCertKey("ns-mysecret", nil, []string{"svc.ns", "svc.ns.svc"})
+	assert.NoError(t, err)
+
+	fullChainCerts, err := cert.ParseCertsPEM(fullChain)
+	assert.NoError(t, err)
+	assert.Len(t, fullChainCerts, 2, "GenerateSelfSignedCertKey is expected to return leaf+CA")
+
+	caOnlyPEM, err := caOnly(fullChain)
+	assert.NoError(t, err)
+	assert.Less(t, len(caOnlyPEM), len(fullChain), "CA-only bundle should be smaller than the full chain")
+
+	caOnlyCerts, err := cert.ParseCertsPEM(caOnlyPEM)
+	assert.NoError(t, err)
+	assert.Len(t, caOnlyCerts, 1)
+	assert.True(t, caOnlyCerts[0].IsCA)
+	assert.Equal(t, fullChainCerts[len(fullChainCerts)-1].Raw, caOnlyCerts[0].Raw)
+}
+
+func TestCAOnly_InvalidPEM(t *testing.T) {
+	_, err := caOnly([]byte("not a cert"))
+	assert.Error(t, err)
+}
+
+func TestHandler_CABundleFor(t *testing.T) {
+	fullChain, _, err := cert.GenerateSelfSignedCertKey("ns-mysecret", nil, []string{"svc.ns", "svc.ns.svc"})
+	assert.NoError(t, err)
+	secret := &corev1.Secret{
+		Data: map[string][]byte{
+			corev1.TLSCertKey: fullChain,
+		},
+	}
+
+	t.Run("nil service returns full chain", func(t *testing.T) {
+		bundle, err := caBundleFor(nil, secret)
+		assert.NoError(t, err)
+		assert.Equal(t, fullChain, bundle)
+	})
+
+	t.Run("no annotation returns full chain", func(t *testing.T) {
+		svc := &corev1.Service{}
+		bundle, err := caBundleFor(svc, secret)
+		assert.NoError(t, err)
+		assert.Equal(t, fullChain, bundle)
+	})
+
+	t.Run("unrecognized annotation value returns full chain", func(t *testing.T) {
+		svc := &corev1.Service{
+			ObjectMeta: metav1.ObjectMeta{
+				Annotations: map[string]string{CABundleModeAnnotation: "bogus"},
+			},
+		}
+		bundle, err := caBundleFor(svc, secret)
+		assert.NoError(t, err)
+		assert.Equal(t, fullChain, bundle)
+	})
+
+	t.Run("ca-only annotation returns just the CA cert", func(t *testing.T) {
+		svc := &corev1.Service{
+			ObjectMeta: metav1.ObjectMeta{
+				Annotations: map[string]string{CABundleModeAnnotation: CABundleModeCAOnly},
+			},
+		}
+		bundle, err := caBundleFor(svc, secret)
+		assert.NoError(t, err)
+		assert.NotEqual(t, fullChain, bundle)
+		assert.Less(t, len(bundle), len(fullChain))
+
+		certs, err := cert.ParseCertsPEM(bundle)
+		assert.NoError(t, err)
+		assert.Len(t, certs, 1)
+		assert.True(t, certs[0].IsCA)
+	})
+
+	t.Run("full-chain annotation explicitly keeps full chain", func(t *testing.T) {
+		svc := &corev1.Service{
+			ObjectMeta: metav1.ObjectMeta{
+				Annotations: map[string]string{CABundleModeAnnotation: CABundleModeFullChain},
+			},
+		}
+		bundle, err := caBundleFor(svc, secret)
+		assert.NoError(t, err)
+		assert.Equal(t, fullChain, bundle)
+	})
+}
+
+func TestHandler_OnMutationWebhookChange_CAOnlyAnnotation(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	mockServiceCache := fake.NewMockCacheInterface[*corev1.Service](ctrl)
+	mockServices := fake.NewMockControllerInterface[*corev1.Service, *corev1.ServiceList](ctrl)
+	mockSecretsCache := fake.NewMockCacheInterface[*corev1.Secret](ctrl)
+	mockSecrets := fake.NewMockControllerInterface[*corev1.Secret, *corev1.SecretList](ctrl)
+	mockMutatingWebHooks := fake.NewMockNonNamespacedControllerInterface[*adminregv1.MutatingWebhookConfiguration, *adminregv1.MutatingWebhookConfigurationList](ctrl)
+
+	mockService := &corev1.Service{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "svc",
+			Namespace: "ns",
+			Annotations: map[string]string{
+				SecretAnnotation:       "mysecret",
+				CABundleModeAnnotation: CABundleModeCAOnly,
+			},
+		},
+	}
+	certPEM, keyPEM, _ := cert.GenerateSelfSignedCertKey("ns-mysecret", nil, []string{"svc.ns", "svc.ns.svc"})
+	mockSecret := &corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "mysecret",
+			Namespace: "ns",
+		},
+		Type: corev1.SecretTypeTLS,
+		Data: map[string][]byte{
+			corev1.TLSCertKey:       certPEM,
+			corev1.TLSPrivateKeyKey: keyPEM,
+		},
+	}
+
+	mockServices.EXPECT().
+		EnqueueAfter("ns", "svc", gomock.Any()).
+		AnyTimes()
+	mockServiceCache.EXPECT().
+		Get("ns", "svc").
+		Return(mockService, nil)
+	mockSecretsCache.EXPECT().
+		Get("ns", "mysecret").
+		Return(mockSecret, nil)
+	mockSecrets.EXPECT().
+		Update(gomock.Any()).
+		DoAndReturn(func(secret *corev1.Secret) (*corev1.Secret, error) {
+			return secret, nil
+		})
+	mockMutatingWebHooks.EXPECT().
+		Update(gomock.Any()).
+		DoAndReturn(func(webhook *adminregv1.MutatingWebhookConfiguration) (*adminregv1.MutatingWebhookConfiguration, error) {
+			return webhook, nil
+		})
+
+	h := &handler{
+		services:         mockServices,
+		serviceCache:     mockServiceCache,
+		secretsCache:     mockSecretsCache,
+		secrets:          mockSecrets,
+		mutatingWebHooks: mockMutatingWebHooks,
+	}
+
+	webhook := &adminregv1.MutatingWebhookConfiguration{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "webhook",
+		},
+		Webhooks: []adminregv1.MutatingWebhook{
+			{
+				Name: "wh",
+				ClientConfig: adminregv1.WebhookClientConfig{
+					Service: &adminregv1.ServiceReference{
+						Namespace: "ns",
+						Name:      "svc",
+					},
+					CABundle: []byte{},
+				},
+			},
+		},
+	}
+
+	updated, err := h.OnMutationWebhookChange("key", webhook)
+	assert.NoError(t, err)
+	assert.NotNil(t, updated)
+	bundle := updated.Webhooks[0].ClientConfig.CABundle
+	assert.NotEmpty(t, bundle)
+	assert.Less(t, len(bundle), len(certPEM))
+
+	certs, err := cert.ParseCertsPEM(bundle)
+	assert.NoError(t, err)
+	assert.Len(t, certs, 1)
+	assert.True(t, certs[0].IsCA)
+}
+
+// TestHandler_OnMutationWebhookChange_PerServiceAnnotationScoping proves that
+// CABundleModeAnnotation lets one Service opt into CA-only CABundles without
+// affecting a sibling Service on the same handler that hasn't opted in - the
+// scenario needed so only a specific consumer (e.g. a CAPI provider) is
+// affected, not every webhook sharing the same needacert controller.
+func TestHandler_OnMutationWebhookChange_PerServiceAnnotationScoping(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	mockServiceCache := fake.NewMockCacheInterface[*corev1.Service](ctrl)
+	mockServices := fake.NewMockControllerInterface[*corev1.Service, *corev1.ServiceList](ctrl)
+	mockSecretsCache := fake.NewMockCacheInterface[*corev1.Secret](ctrl)
+	mockSecrets := fake.NewMockControllerInterface[*corev1.Secret, *corev1.SecretList](ctrl)
+	mockMutatingWebHooks := fake.NewMockNonNamespacedControllerInterface[*adminregv1.MutatingWebhookConfiguration, *adminregv1.MutatingWebhookConfigurationList](ctrl)
+
+	optedInService := &corev1.Service{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "turtles-svc",
+			Namespace: "ns",
+			Annotations: map[string]string{
+				SecretAnnotation:       "turtles-secret",
+				CABundleModeAnnotation: "ca-only",
+			},
+		},
+	}
+	defaultService := &corev1.Service{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "other-svc",
+			Namespace: "ns",
+			Annotations: map[string]string{
+				SecretAnnotation: "other-secret",
+			},
+		},
+	}
+
+	turtlesCertPEM, turtlesKeyPEM, _ := cert.GenerateSelfSignedCertKey("ns-turtles-secret", nil, []string{"turtles-svc.ns"})
+	turtlesSecret := &corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{Name: "turtles-secret", Namespace: "ns"},
+		Type:       corev1.SecretTypeTLS,
+		Data: map[string][]byte{
+			corev1.TLSCertKey:       turtlesCertPEM,
+			corev1.TLSPrivateKeyKey: turtlesKeyPEM,
+		},
+	}
+	otherCertPEM, otherKeyPEM, _ := cert.GenerateSelfSignedCertKey("ns-other-secret", nil, []string{"other-svc.ns"})
+	otherSecret := &corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{Name: "other-secret", Namespace: "ns"},
+		Type:       corev1.SecretTypeTLS,
+		Data: map[string][]byte{
+			corev1.TLSCertKey:       otherCertPEM,
+			corev1.TLSPrivateKeyKey: otherKeyPEM,
+		},
+	}
+
+	mockServices.EXPECT().EnqueueAfter(gomock.Any(), gomock.Any(), gomock.Any()).AnyTimes()
+	mockServiceCache.EXPECT().Get("ns", "turtles-svc").Return(optedInService, nil)
+	mockServiceCache.EXPECT().Get("ns", "other-svc").Return(defaultService, nil)
+	mockSecretsCache.EXPECT().Get("ns", "turtles-secret").Return(turtlesSecret, nil)
+	mockSecretsCache.EXPECT().Get("ns", "other-secret").Return(otherSecret, nil)
+	mockSecrets.EXPECT().Update(gomock.Any()).DoAndReturn(func(secret *corev1.Secret) (*corev1.Secret, error) {
+		return secret, nil
+	}).Times(2)
+	mockMutatingWebHooks.EXPECT().Update(gomock.Any()).DoAndReturn(func(webhook *adminregv1.MutatingWebhookConfiguration) (*adminregv1.MutatingWebhookConfiguration, error) {
+		return webhook, nil
+	})
+
+	// Neither service opts in via anything but its own annotation - only
+	// optedInService should get a CA-only bundle.
+	h := &handler{
+		services:         mockServices,
+		serviceCache:     mockServiceCache,
+		secretsCache:     mockSecretsCache,
+		secrets:          mockSecrets,
+		mutatingWebHooks: mockMutatingWebHooks,
+	}
+
+	webhook := &adminregv1.MutatingWebhookConfiguration{
+		ObjectMeta: metav1.ObjectMeta{Name: "webhook"},
+		Webhooks: []adminregv1.MutatingWebhook{
+			{
+				Name: "turtles",
+				ClientConfig: adminregv1.WebhookClientConfig{
+					Service:  &adminregv1.ServiceReference{Namespace: "ns", Name: "turtles-svc"},
+					CABundle: []byte{},
+				},
+			},
+			{
+				Name: "other",
+				ClientConfig: adminregv1.WebhookClientConfig{
+					Service:  &adminregv1.ServiceReference{Namespace: "ns", Name: "other-svc"},
+					CABundle: []byte{},
+				},
+			},
+		},
+	}
+
+	updated, err := h.OnMutationWebhookChange("key", webhook)
+	assert.NoError(t, err)
+	assert.NotNil(t, updated)
+
+	turtlesBundle := updated.Webhooks[0].ClientConfig.CABundle
+	otherBundle := updated.Webhooks[1].ClientConfig.CABundle
+
+	turtlesCerts, err := cert.ParseCertsPEM(turtlesBundle)
+	assert.NoError(t, err)
+	assert.Len(t, turtlesCerts, 1, "opted-in service should get a CA-only bundle")
+	assert.True(t, turtlesCerts[0].IsCA)
+
+	otherCerts, err := cert.ParseCertsPEM(otherBundle)
+	assert.NoError(t, err)
+	assert.Len(t, otherCerts, 2, "service without the annotation should keep the full leaf+CA chain")
+}
+
 func TestHandler_ParseCert_CorruptedData(t *testing.T) {
 	secret := &corev1.Secret{
 		ObjectMeta: metav1.ObjectMeta{

--- a/pkg/needacert/needacert_test.go
+++ b/pkg/needacert/needacert_test.go
@@ -2,6 +2,7 @@ package needacert
 
 import (
 	"bytes"
+	"encoding/pem"
 	"fmt"
 	"math"
 	"testing"
@@ -859,6 +860,22 @@ func TestCAOnly(t *testing.T) {
 	assert.Len(t, caOnlyCerts, 1)
 	assert.True(t, caOnlyCerts[0].IsCA)
 	assert.Equal(t, fullChainCerts[len(fullChainCerts)-1].Raw, caOnlyCerts[0].Raw)
+}
+
+func TestCAOnly_SingleCert(t *testing.T) {
+	fullChain, _, err := cert.GenerateSelfSignedCertKey("ns-mysecret", nil, []string{"svc.ns", "svc.ns.svc"})
+	assert.NoError(t, err)
+
+	// Strip the chain down to just the leaf cert, so caOnly sees a single-cert
+	// PEM blob (as if the CA had already been dropped, or a bundle was never
+	// chained in the first place).
+	leafBlock, _ := pem.Decode(fullChain)
+	assert.NotNil(t, leafBlock)
+	leafOnlyPEM := pem.EncodeToMemory(leafBlock)
+
+	result, err := caOnly(leafOnlyPEM)
+	assert.NoError(t, err)
+	assert.Equal(t, leafOnlyPEM, result, "single-cert chain should be returned unmodified, not re-encoded")
 }
 
 func TestCAOnly_InvalidPEM(t *testing.T) {


### PR DESCRIPTION
Issue: https://github.com/rancher/rancher/issues/56116
Issue:  https://github.com/rancher/turtles/issues/2452

Support service annotation to enable/disable "ca-only" mode vs default of chaining all certs together.