### PR TITLE
Migrate renovate config to per-release-line presets

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -25,9 +25,9 @@
       "extends": ["github>rancher/renovate-config:rancher-2.14#main"]
     },
     {
-      "description": "release/v3.3 is shared by rancher release/v2.12 and release/v2.13; use the older/tighter of the two ceilings",
+      "description": "release/v3.3 is shared by rancher release/v2.11, release/v2.12, and release/v2.13; use the oldest/tightest of the three ceilings",
       "matchBaseBranches": ["release/v3.3"],
-      "extends": ["github>rancher/renovate-config:rancher-2.12#main"]
+      "extends": ["github>rancher/renovate-config:rancher-2.11#main"]
     },
     {
       "description": "release/v2 predates every per-release-line preset and has no active consumer; keep it fully disabled for k8s.io/sigs.k8s.io rather than adopting a ceiling that doesn't apply to it",

--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -16,10 +16,31 @@
   ],
   "packageRules": [
     {
+      "matchBaseBranches": ["main"],
+      "extends": ["github>rancher/renovate-config:rancher-main#main"]
+    },
+    {
+      "description": "release/v3.6 is only consumed by rancher release/v2.14",
+      "matchBaseBranches": ["release/v3.6"],
+      "extends": ["github>rancher/renovate-config:rancher-2.14#main"]
+    },
+    {
+      "description": "release/v3.3 is shared by rancher release/v2.12 and release/v2.13; use the older/tighter of the two ceilings",
+      "matchBaseBranches": ["release/v3.3"],
+      "extends": ["github>rancher/renovate-config:rancher-2.12#main"]
+    },
+    {
+      "description": "release/v2 predates every per-release-line preset and has no active consumer; keep it fully disabled for k8s.io/sigs.k8s.io rather than adopting a ceiling that doesn't apply to it",
       "enabled": false,
+      "matchBaseBranches": ["release/v2"],
       "matchPackageNames": [
         "/k8s.io/*/",
-        "/sigs.k8s.io/*/",
+        "/sigs.k8s.io/*/"
+      ]
+    },
+    {
+      "enabled": false,
+      "matchPackageNames": [
         "/go.opentelemetry.io/*/",
         "/github.com/prometheus/*/",
         "/github.com/rancher/lasso/*/"


### PR DESCRIPTION
Replaces the repo-local k8s.io/sigs.k8s.io disable rule with per-branch `extends` of `rancher/renovate-config`'s per-release-line presets, per rancher/rancher#50186.


| wrangler branch | preset | why |
|---|---|---|
| main | rancher-main | forward-looking, same convention as other repos |
| release/v3.6 | rancher-2.14 | only consumer |
| release/v3.3 | rancher-2.11 | consumed by rancher release/v2.11, release/v2.12, and release/v2.13; using the oldest/tightest of the three ceilings avoids proposing a bump the older lines can't absorb |
| release/v2 | unchanged | v2 not used |