### PR TITLE
Support Rancher operation CRDs

### DIFF
--- a/pkg/summary/operations.go
+++ b/pkg/summary/operations.go
@@ -12,10 +12,11 @@ var operationKinds = map[string]bool{
 	"EncryptionKeyRotation": true,
 	"ETCDSnapshotRestore":   true,
 	"ETCDSnapshotSave":      true,
+	"CertificateRotation":   true,
 }
 
 // isOperation returns true if the object is a Rancher operation
-// (operation.cattle.io/*/{EncryptionKeyRotation,ETCDSnapshotRestore,ETCDSnapshotSave}).
+// (operation.cattle.io/*/{EncryptionKeyRotation,ETCDSnapshotRestore,ETCDSnapshotSave,CertificateRotation}).
 func isOperation(obj data.Object) bool {
 	return strings.HasPrefix(obj.String("apiVersion"), "operation.cattle.io/") &&
 		operationKinds[obj.String("kind")]

--- a/pkg/summary/operations.go
+++ b/pkg/summary/operations.go
@@ -1,0 +1,85 @@
+package summary
+
+import (
+	"strings"
+
+	"github.com/rancher/wrangler/v3/pkg/data"
+)
+
+// operationKinds are the operation.cattle.io kinds that embed the shared
+// OperationStatus contract.
+var operationKinds = map[string]bool{
+	"EncryptionKeyRotation": true,
+	"ETCDSnapshotRestore":   true,
+	"ETCDSnapshotSave":      true,
+}
+
+// isOperation returns true if the object is a Rancher operation
+// (operation.cattle.io/*/{EncryptionKeyRotation,ETCDSnapshotRestore,ETCDSnapshotSave}).
+func isOperation(obj data.Object) bool {
+	return strings.HasPrefix(obj.String("apiVersion"), "operation.cattle.io/") &&
+		operationKinds[obj.String("kind")]
+}
+
+// operationStates maps each operation condition to the summary it implies, in
+// priority order.
+var operationStates = []struct {
+	condition     string
+	state         string
+	err           bool
+	transitioning bool
+}{
+	{condition: "Failed", state: "failed", err: true},
+	{condition: "Canceled", state: "canceled", err: true},
+	{condition: "Succeeded", state: "succeeded"},
+	{condition: "Paused", state: "paused", transitioning: true},
+	{condition: "InProgress", state: "in-progress", transitioning: true},
+	{condition: "Pending", state: "pending", transitioning: true},
+}
+
+// checkOperationTransitioning computes summary state for Rancher operations.
+//
+// Operations carry one condition per lifecycle phase (Pending, InProgress,
+// Succeeded, Failed, Canceled) plus Paused. These mirror status.phase rather
+// than expressing readiness, so True is the normal state for every one of them
+// and the generic TransitioningUnknown/False/True tables do not apply.
+//
+// The first condition in operationStates whose status is True wins. Priority
+// matters because Rancher does not clear the conditions of prior phases: a
+// canceled operation retains InProgress=True, and terminal conditions must
+// outrank Paused so that a paused-but-finished operation reads as finished.
+//
+// When conditions exist but none are True the summary passes through untouched,
+// leaving checkPhase to name the state.
+func checkOperationTransitioning(conditions []Condition, summary Summary) Summary {
+	for _, state := range operationStates {
+		for _, c := range conditions {
+			if c.Type() != state.condition || c.Status() != "True" {
+				continue
+			}
+
+			summary.State = state.state
+			if state.err {
+				summary.Error = true
+			}
+			if state.transitioning {
+				summary.Transitioning = true
+			}
+			if msg := c.Message(); msg != "" {
+				summary.Message = append(summary.Message, msg)
+			}
+
+			return summary
+		}
+	}
+
+	// Rancher writes a condition alongside every phase, so an operation with no
+	// conditions has not been reconciled yet. Without this, the kstatus fallback
+	// in checkStandard reports a brand-new operation as active.
+	if len(conditions) == 0 {
+		summary.State = "pending"
+		summary.Transitioning = true
+	}
+
+	return summary
+}

--- a/pkg/summary/operations_test.go
+++ b/pkg/summary/operations_test.go
@@ -30,8 +30,8 @@ func TestIsOperation(t *testing.T) {
 			expected: true,
 		},
 		{
-			name:     "future API version of the same group",
-			obj:      data.Object{"apiVersion": "operation.cattle.io/v1", "kind": "ETCDSnapshotSave"},
+			name:     "CertificateRotation",
+			obj:      data.Object{"apiVersion": "operation.cattle.io/v1alpha1", "kind": "CertificateRotation"},
 			expected: true,
 		},
 		{
@@ -203,16 +203,16 @@ func TestCheckOperationTransitioning(t *testing.T) {
 
 // makeOperationObj builds an operation.cattle.io object with the given phase,
 // step and conditions.
-func makeOperationObj(kind, phase, step string, conditions ...map[string]interface{}) *unstructured.Unstructured {
-	raw := make([]interface{}, 0, len(conditions))
+func makeOperationObj(kind, phase, step string, conditions ...map[string]any) *unstructured.Unstructured {
+	raw := make([]any, 0, len(conditions))
 	for _, c := range conditions {
 		raw = append(raw, c)
 	}
-	return &unstructured.Unstructured{Object: map[string]interface{}{
+	return &unstructured.Unstructured{Object: map[string]any{
 		"apiVersion": "operation.cattle.io/v1alpha1",
 		"kind":       kind,
-		"metadata":   map[string]interface{}{"name": "op", "namespace": "fleet-default"},
-		"status": map[string]interface{}{
+		"metadata":   map[string]any{"name": "op", "namespace": "fleet-default"},
+		"status": map[string]any{
 			"phase":              phase,
 			"step":               step,
 			"observedGeneration": int64(1),
@@ -221,8 +221,8 @@ func makeOperationObj(kind, phase, step string, conditions ...map[string]interfa
 	}}
 }
 
-func cond(condType, status, reason, message string) map[string]interface{} {
-	return map[string]interface{}{
+func cond(condType, status, reason, message string) map[string]any {
+	return map[string]any{
 		"type":    condType,
 		"status":  status,
 		"reason":  reason,
@@ -233,7 +233,7 @@ func cond(condType, status, reason, message string) map[string]interface{} {
 // TestSummarizeOperation exercises the whole summarizer chain, which is where
 // the reported inaccuracy surfaced.
 func TestSummarizeOperation(t *testing.T) {
-	inProgressConditions := []map[string]interface{}{
+	inProgressConditions := []map[string]any{
 		cond("InProgress", "True", "WaitingForPlanApplied", "Waiting in step Preflight: failing plan for machine-7qrnd"),
 		cond("Paused", "False", "NotPaused", ""),
 		cond("Pending", "False", "InProgress", "Operation now in progress"),
@@ -273,10 +273,10 @@ func TestSummarizeOperation(t *testing.T) {
 		},
 		{
 			name: "freshly created, no status yet",
-			obj: &unstructured.Unstructured{Object: map[string]interface{}{
+			obj: &unstructured.Unstructured{Object: map[string]any{
 				"apiVersion": "operation.cattle.io/v1alpha1",
 				"kind":       "EncryptionKeyRotation",
-				"metadata":   map[string]interface{}{"name": "op", "namespace": "fleet-default"},
+				"metadata":   map[string]any{"name": "op", "namespace": "fleet-default"},
 			}},
 			expected: Summary{State: "pending", Transitioning: true},
 		},

--- a/pkg/summary/operations_test.go
+++ b/pkg/summary/operations_test.go
@@ -1,0 +1,334 @@
+package summary
+
+import (
+	"testing"
+
+	"github.com/rancher/wrangler/v3/pkg/data"
+	"github.com/stretchr/testify/assert"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+)
+
+func TestIsOperation(t *testing.T) {
+	tests := []struct {
+		name     string
+		obj      data.Object
+		expected bool
+	}{
+		{
+			name:     "EncryptionKeyRotation",
+			obj:      data.Object{"apiVersion": "operation.cattle.io/v1alpha1", "kind": "EncryptionKeyRotation"},
+			expected: true,
+		},
+		{
+			name:     "ETCDSnapshotRestore",
+			obj:      data.Object{"apiVersion": "operation.cattle.io/v1alpha1", "kind": "ETCDSnapshotRestore"},
+			expected: true,
+		},
+		{
+			name:     "ETCDSnapshotSave",
+			obj:      data.Object{"apiVersion": "operation.cattle.io/v1alpha1", "kind": "ETCDSnapshotSave"},
+			expected: true,
+		},
+		{
+			name:     "future API version of the same group",
+			obj:      data.Object{"apiVersion": "operation.cattle.io/v1", "kind": "ETCDSnapshotSave"},
+			expected: true,
+		},
+		{
+			name:     "unknown kind in the operation group",
+			obj:      data.Object{"apiVersion": "operation.cattle.io/v1alpha1", "kind": "SomethingElse"},
+			expected: false,
+		},
+		{
+			name:     "same kind in a different group",
+			obj:      data.Object{"apiVersion": "rke.cattle.io/v1", "kind": "ETCDSnapshotSave"},
+			expected: false,
+		},
+		{
+			name:     "group is only a prefix of the operation group",
+			obj:      data.Object{"apiVersion": "operation.cattle.io.example/v1", "kind": "ETCDSnapshotSave"},
+			expected: false,
+		},
+		{
+			name:     "empty object",
+			obj:      data.Object{},
+			expected: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.expected, isOperation(tt.obj))
+		})
+	}
+}
+
+func TestCheckOperationTransitioning(t *testing.T) {
+	tests := []struct {
+		name             string
+		conditions       []Condition
+		summary          Summary
+		expectedState    string
+		expectedTransit  bool
+		expectedError    bool
+		expectedMessages []string
+	}{
+		{
+			name: "Pending phase is transitioning, not an error",
+			conditions: []Condition{
+				NewCondition("Pending", "True", "WaitingForBeacon", "Waiting to acquire the beacon"),
+				NewCondition("Paused", "False", "NotPaused", ""),
+			},
+			expectedState:    "pending",
+			expectedTransit:  true,
+			expectedMessages: []string{"Waiting to acquire the beacon"},
+		},
+		{
+			name: "InProgress phase is transitioning, not an error",
+			conditions: []Condition{
+				NewCondition("InProgress", "True", "WaitingForPlanApplied", "Waiting in step Preflight: failing plan for machine-7qrnd"),
+				NewCondition("Paused", "False", "NotPaused", ""),
+				NewCondition("Pending", "False", "InProgress", "Operation now in progress"),
+			},
+			expectedState:    "in-progress",
+			expectedTransit:  true,
+			expectedMessages: []string{"Waiting in step Preflight: failing plan for machine-7qrnd"},
+		},
+		{
+			name: "Succeeded phase is neither transitioning nor an error",
+			conditions: []Condition{
+				NewCondition("Pending", "False", "Finished", "Operation completed successfully"),
+				NewCondition("InProgress", "False", "Finished", "Operation completed successfully"),
+				NewCondition("Succeeded", "True", "Finished", "Operation completed successfully"),
+				NewCondition("Failed", "False", "NotFailed", "Operation completed successfully"),
+			},
+			expectedState:    "succeeded",
+			expectedMessages: []string{"Operation completed successfully"},
+		},
+		{
+			name: "Failed phase is an error",
+			conditions: []Condition{
+				NewCondition("Pending", "False", "Finished", "Operation failed"),
+				NewCondition("InProgress", "False", "Finished", "Operation failed"),
+				NewCondition("Failed", "True", "PlanFailed", "restart failed for ns/secret"),
+				NewCondition("Succeeded", "False", "NotSuccessful", "Operation failed"),
+			},
+			expectedState:    "failed",
+			expectedError:    true,
+			expectedMessages: []string{"restart failed for ns/secret"},
+		},
+		{
+			name: "Canceled phase is an error and outranks a stale InProgress",
+			conditions: []Condition{
+				NewCondition("InProgress", "True", "WaitingForPlanApplied", "Waiting in step Preflight: stale"),
+				NewCondition("Canceled", "True", "PreflightCheckFailed", "could not find server token for ns/secret"),
+			},
+			expectedState:    "canceled",
+			expectedError:    true,
+			expectedMessages: []string{"could not find server token for ns/secret"},
+		},
+		{
+			name: "Failed outranks Canceled",
+			conditions: []Condition{
+				NewCondition("Canceled", "True", "PreflightCheckFailed", "canceled message"),
+				NewCondition("Failed", "True", "PlanFailed", "failed message"),
+			},
+			expectedState:    "failed",
+			expectedError:    true,
+			expectedMessages: []string{"failed message"},
+		},
+		{
+			name: "Paused is transitioning, not an error",
+			conditions: []Condition{
+				NewCondition("Paused", "True", "Paused", "Operation is paused"),
+				NewCondition("InProgress", "True", "WaitingForPlanApplied", "Waiting in step Save"),
+			},
+			expectedState:    "paused",
+			expectedTransit:  true,
+			expectedMessages: []string{"Operation is paused"},
+		},
+		{
+			name: "terminal conditions outrank Paused",
+			conditions: []Condition{
+				NewCondition("Paused", "True", "Paused", "Operation is paused"),
+				NewCondition("Succeeded", "True", "Finished", "Operation completed successfully"),
+			},
+			expectedState:    "succeeded",
+			expectedMessages: []string{"Operation completed successfully"},
+		},
+		{
+			name: "empty condition messages are not appended",
+			conditions: []Condition{
+				NewCondition("Pending", "True", "WaitingForBeacon", ""),
+			},
+			expectedState:   "pending",
+			expectedTransit: true,
+		},
+		{
+			name:            "an unreconciled operation with no conditions is pending",
+			conditions:      nil,
+			expectedState:   "pending",
+			expectedTransit: true,
+		},
+		{
+			name: "no condition set to True passes through untouched",
+			conditions: []Condition{
+				NewCondition("Pending", "False", "InProgress", "Operation now in progress"),
+				NewCondition("Paused", "False", "NotPaused", ""),
+			},
+			expectedState: "",
+		},
+		{
+			name: "an error already set by checkErrors is preserved",
+			conditions: []Condition{
+				NewCondition("Pending", "True", "WaitingForBeacon", ""),
+			},
+			summary:         Summary{Error: true},
+			expectedState:   "pending",
+			expectedTransit: true,
+			expectedError:   true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			actual := checkOperationTransitioning(tt.conditions, tt.summary)
+			assert.Equal(t, tt.expectedState, actual.State)
+			assert.Equal(t, tt.expectedTransit, actual.Transitioning)
+			assert.Equal(t, tt.expectedError, actual.Error)
+			assert.Equal(t, tt.expectedMessages, actual.Message)
+		})
+	}
+}
+
+// makeOperationObj builds an operation.cattle.io object with the given phase,
+// step and conditions.
+func makeOperationObj(kind, phase, step string, conditions ...map[string]interface{}) *unstructured.Unstructured {
+	raw := make([]interface{}, 0, len(conditions))
+	for _, c := range conditions {
+		raw = append(raw, c)
+	}
+	return &unstructured.Unstructured{Object: map[string]interface{}{
+		"apiVersion": "operation.cattle.io/v1alpha1",
+		"kind":       kind,
+		"metadata":   map[string]interface{}{"name": "op", "namespace": "fleet-default"},
+		"status": map[string]interface{}{
+			"phase":              phase,
+			"step":               step,
+			"observedGeneration": int64(1),
+			"conditions":         raw,
+		},
+	}}
+}
+
+func cond(condType, status, reason, message string) map[string]interface{} {
+	return map[string]interface{}{
+		"type":    condType,
+		"status":  status,
+		"reason":  reason,
+		"message": message,
+	}
+}
+
+// TestSummarizeOperation exercises the whole summarizer chain, which is where
+// the reported inaccuracy surfaced.
+func TestSummarizeOperation(t *testing.T) {
+	inProgressConditions := []map[string]interface{}{
+		cond("InProgress", "True", "WaitingForPlanApplied", "Waiting in step Preflight: failing plan for machine-7qrnd"),
+		cond("Paused", "False", "NotPaused", ""),
+		cond("Pending", "False", "InProgress", "Operation now in progress"),
+	}
+
+	tests := []struct {
+		name     string
+		obj      *unstructured.Unstructured
+		expected Summary
+	}{
+		{
+			name: "EncryptionKeyRotation in progress",
+			obj:  makeOperationObj("EncryptionKeyRotation", "InProgress", "Rotate", inProgressConditions...),
+			expected: Summary{
+				State:         "in-progress",
+				Transitioning: true,
+				Message:       []string{"Waiting in step Preflight: failing plan for machine-7qrnd"},
+			},
+		},
+		{
+			name: "ETCDSnapshotSave in progress",
+			obj:  makeOperationObj("ETCDSnapshotSave", "InProgress", "Save", inProgressConditions...),
+			expected: Summary{
+				State:         "in-progress",
+				Transitioning: true,
+				Message:       []string{"Waiting in step Preflight: failing plan for machine-7qrnd"},
+			},
+		},
+		{
+			name: "ETCDSnapshotRestore in progress",
+			obj:  makeOperationObj("ETCDSnapshotRestore", "InProgress", "Shutdown", inProgressConditions...),
+			expected: Summary{
+				State:         "in-progress",
+				Transitioning: true,
+				Message:       []string{"Waiting in step Preflight: failing plan for machine-7qrnd"},
+			},
+		},
+		{
+			name: "freshly created, no status yet",
+			obj: &unstructured.Unstructured{Object: map[string]interface{}{
+				"apiVersion": "operation.cattle.io/v1alpha1",
+				"kind":       "EncryptionKeyRotation",
+				"metadata":   map[string]interface{}{"name": "op", "namespace": "fleet-default"},
+			}},
+			expected: Summary{State: "pending", Transitioning: true},
+		},
+		{
+			name: "pending",
+			obj: makeOperationObj("ETCDSnapshotSave", "Pending", "",
+				cond("Pending", "True", "WaitingForBeacon", ""),
+				cond("Paused", "False", "NotPaused", ""),
+			),
+			expected: Summary{State: "pending", Transitioning: true},
+		},
+		{
+			name: "succeeded",
+			obj: makeOperationObj("ETCDSnapshotSave", "Succeeded", "",
+				cond("Pending", "False", "Finished", "Operation completed successfully"),
+				cond("InProgress", "False", "Finished", "Operation completed successfully"),
+				cond("Succeeded", "True", "Finished", "Operation completed successfully"),
+				cond("Failed", "False", "NotFailed", "Operation completed successfully"),
+			),
+			expected: Summary{State: "succeeded", Message: []string{"Operation completed successfully"}},
+		},
+		{
+			name: "failed",
+			obj: makeOperationObj("ETCDSnapshotSave", "Failed", "Restart",
+				cond("Pending", "False", "Finished", "Operation failed"),
+				cond("InProgress", "False", "Finished", "Operation failed"),
+				cond("Failed", "True", "PlanFailed", "restart failed for ns/secret"),
+				cond("Succeeded", "False", "NotSuccessful", "Operation failed"),
+			),
+			expected: Summary{
+				State:   "failed",
+				Error:   true,
+				Message: []string{"restart failed for ns/secret"},
+			},
+		},
+		{
+			name: "canceled with a stale InProgress condition",
+			obj: makeOperationObj("ETCDSnapshotSave", "Canceled", "Preflight",
+				cond("InProgress", "True", "WaitingForPlanApplied", "Waiting in step Preflight: stale"),
+				cond("Canceled", "True", "PreflightCheckFailed", "could not find server token for ns/secret"),
+			),
+			expected: Summary{
+				State:   "canceled",
+				Error:   true,
+				Message: []string{"could not find server token for ns/secret"},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.expected, Summarize(tt.obj))
+		})
+	}
+}

--- a/pkg/summary/summarizers.go
+++ b/pkg/summary/summarizers.go
@@ -374,6 +374,9 @@ func checkTransitioning(obj data.Object, conditions []Condition, summary Summary
 	if isCAPICluster(obj) {
 		return checkCAPIClusterTransitioning(obj, conditions, summary)
 	}
+	if isOperation(obj) {
+		return checkOperationTransitioning(conditions, summary)
+	}
 	return checkGenericTransitioning(obj, conditions, summary)
 }
 


### PR DESCRIPTION
**Issue**:
- https://github.com/rancher/rancher/issues/56075

**Problem**:

Operation conditions appear incorrectly in the UI, showing red with the text `Pending`, even though the operation has moved to a different state. 
This is due to a quirk within Wrangler's summarization.

**Fix**:

Adds first-class summary/transitioning support for Rancher `operation.cattle.io` CRDs, `EncryptionKeyRotation`, `ETCDSnapshotRestore`, and `ETCDSnapshotSave`, so their lifecycle conditions map to the correct Wrangler Summary state/flags rather than relying on the generic condition tables.


**Dev Validation**:

The changes were validated on a customized Rancher image where the Wrangler module was replaced with this branch.  I confirmed that the UI showed the color and message accurately for those three CRDs. 

<img width="4064" height="2724" alt="ex2" src="https://github.com/user-attachments/assets/c5c2ee89-41fb-4694-89b2-a05fcd99d7c9" />

<img width="4064" height="2724" alt="eample" src="https://github.com/user-attachments/assets/35dce81e-01ff-4586-99a2-02b9c322c2cb" />

<img width="4064" height="2724" alt="ex4" src="https://github.com/user-attachments/assets/f5d22818-bc85-4fe0-9677-50b1c95423a3" />

<img width="1654" height="349" alt="Screenshot 2026-07-30 at 12 17 45 PM" src="https://github.com/user-attachments/assets/1c9df21a-9379-4dcc-be6e-20f6adc873ab" />


