### PR TITLE
Add AgentRestart field to schemas.Field for KDM agent-restart metadata

### DIFF
--- a/pkg/schemas/types.go
+++ b/pkg/schemas/types.go
@@ -114,6 +114,7 @@ type Field struct {
 	InvalidChars string      `json:"invalidChars,omitempty"`
 	Description  string      `json:"description,omitempty"`
 	CodeName     string      `json:"-"`
+	AgentRestart bool        `json:"agentRestart,omitempty"`
 }
 
 type Action struct {


### PR DESCRIPTION
 Part of https://github.com/rancher/rancher/issues/55326
## What this does

  Adds an optional `AgentRestart` boolean field to `schemas.Field` (`pkg/schemas/types.go`).

  This lets KDM `serverArgs`/`agentArgs` entries carry an `agentRestart` flag indicating that
  toggling the argument requires affected agents to restart to pick up the change.

  ## Why

  Some server-only flags (e.g. `disable-kube-proxy`) affect agent behavior but are stripped
  from worker config, so workers never restart when they change. Making this data-driven via
  KDM lets Rancher decide which flags force an agent restart without hardcoding the list.

  ## Related PRs

  - KDM: https://github.com/rancher/kontainer-driver-metadata/pull/2156
  - Rancher: https://github.com/rancher/rancher/pull/56603
