### PR TITLE
Add support for server-side apply (field management) in generated clients and fakes

### DIFF
--- a/pkg/controller-gen/generators/models_generator.go
+++ b/pkg/controller-gen/generators/models_generator.go
@@ -1,0 +1,69 @@
+package generators
+
+import (
+	"path"
+	"path/filepath"
+
+	args "github.com/rancher/wrangler/v3/pkg/controller-gen/args"
+	"github.com/sirupsen/logrus"
+	"k8s.io/gengo/v2"
+	"k8s.io/gengo/v2/generator"
+	oaargs "k8s.io/kube-openapi/cmd/openapi-gen/args"
+	oa "k8s.io/kube-openapi/pkg/generators"
+)
+
+type ModelsGenerator struct {
+}
+
+func NewOpenAPIGenerator() *ModelsGenerator {
+	return &ModelsGenerator{}
+}
+
+func (mg *ModelsGenerator) GetOpenAPITargets(context *generator.Context, customArgs *args.CustomArgs) []generator.Target {
+	openAPIArgs := oaargs.New()
+	openAPIArgs.OutputDir = filepath.Join(customArgs.OutputBase, customArgs.Options.OutputPackage, "openapi")
+	openAPIArgs.OutputFile = "zz_generated_openapi.go"
+	openAPIArgs.OutputPkg = filepath.Join(customArgs.Options.OutputPackage, "openapi")
+	openAPIArgs.GoHeaderFile = customArgs.Options.Boilerplate
+	openAPIArgs.OutputModelNameFile = "zz_generated.model_name.go"
+
+	if err := openAPIArgs.Validate(); err != nil {
+		logrus.Fatalf("Failed to validate openapi-gen args: %v", err)
+	}
+
+	boilerplate, err := gengo.GoBoilerplate(openAPIArgs.GoHeaderFile, gengo.StdBuildTag, gengo.StdGeneratedBy)
+	if err != nil {
+		logrus.Fatalf("Failed to generate openapi boilerplate: %v", err)
+	}
+
+	return append(oa.GetOpenAPITargets(context, openAPIArgs, boilerplate), generator.SimpleTarget{
+		PkgName:       "main",
+		PkgPath:       path.Join(customArgs.Package, "openapi", "cmd", "models-schema"),
+		PkgDir:        filepath.Join(customArgs.OutputBase, customArgs.Package, "openapi", "cmd", "models-schema"),
+		HeaderComment: customArgs.BoilerplateContent,
+		GeneratorsFunc: func(context *generator.Context) []generator.Generator {
+			return []generator.Generator{
+				ModelsSchemaCmdGo(customArgs),
+			}
+		}})
+}
+
+func (mg *ModelsGenerator) GetModelNameTargets(context *generator.Context, customArgs *args.CustomArgs) []generator.Target {
+	openAPIArgs := oaargs.New()
+	openAPIArgs.OutputDir = filepath.Join(customArgs.OutputBase, customArgs.Options.OutputPackage, "openapi")
+	openAPIArgs.OutputFile = "zz_generated_openapi.go"
+	openAPIArgs.OutputPkg = filepath.Join(customArgs.Options.OutputPackage, "openapi")
+	openAPIArgs.GoHeaderFile = customArgs.Options.Boilerplate
+	openAPIArgs.OutputModelNameFile = "zz_generated.model_name.go"
+
+	if err := openAPIArgs.Validate(); err != nil {
+		logrus.Fatalf("Failed to validate openapi-gen args: %v", err)
+	}
+
+	boilerplate, err := gengo.GoBoilerplate(openAPIArgs.GoHeaderFile, gengo.StdBuildTag, gengo.StdGeneratedBy)
+	if err != nil {
+		logrus.Fatalf("Failed to generate openapi boilerplate: %v", err)
+	}
+
+	return oa.GetModelNameTargets(context, openAPIArgs, boilerplate)
+}

--- a/pkg/controller-gen/generators/models_schema.go
+++ b/pkg/controller-gen/generators/models_schema.go
@@ -1,0 +1,86 @@
+package generators
+
+import (
+	"path"
+
+	"github.com/rancher/wrangler/v3/pkg/controller-gen/args"
+	"k8s.io/gengo/v2/generator"
+)
+
+func ModelsSchemaCmdGo(customArgs *args.CustomArgs) generator.Generator {
+	return &modelsSchemaCmdGo{
+		customArgs: customArgs,
+		GoGenerator: generator.GoGenerator{
+			OutputFilename: "main.go",
+			OptionalBody:   []byte(modelsSchemaCmdBody),
+		},
+	}
+}
+
+type modelsSchemaCmdGo struct {
+	generator.GoGenerator
+
+	customArgs *args.CustomArgs
+}
+
+func (m *modelsSchemaCmdGo) Imports(*generator.Context) []string {
+	return []string{
+		"encoding/json",
+		"fmt",
+		"os",
+		path.Join(m.customArgs.Package, "openapi"),
+		"k8s.io/kube-openapi/pkg/common",
+		"k8s.io/kube-openapi/pkg/validation/spec",
+	}
+}
+
+var modelsSchemaCmdBody = `
+// Outputs openAPI schema JSON containing the schema definitions in zz_generated.openapi.go.
+func main() {
+	err := output()
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "Failed: %v", err) //nolint:errcheck
+		os.Exit(1)
+	}
+}
+
+func output() error {
+	refFunc := func(name string) spec.Ref {
+		return spec.MustCreateRef(fmt.Sprintf("#/definitions/%s", name))
+	}
+	defs := openapi.GetOpenAPIDefinitions(refFunc)
+	schemaDefs := make(map[string]spec.Schema, len(defs))
+	for k, v := range defs {
+		// Replace top-level schema with v2 if a v2 schema is embedded
+		// so that the output of this program is always in OpenAPI v2.
+		// This is done by looking up an extension that marks the embedded v2
+		// schema, and, if the v2 schema is found, make it the resulting schema for
+		// the type.
+		if schema, ok := v.Schema.Extensions[common.ExtensionV2Schema]; ok {
+			if v2Schema, isOpenAPISchema := schema.(spec.Schema); isOpenAPISchema {
+				schemaDefs[k] = v2Schema
+				continue
+			}
+		}
+
+		schemaDefs[k] = v.Schema
+	}
+	data, err := json.Marshal(&spec.Swagger{
+		SwaggerProps: spec.SwaggerProps{
+			Definitions: schemaDefs,
+			Info: &spec.Info{
+				InfoProps: spec.InfoProps{
+					Title:   "Kubernetes",
+					Version: "unversioned",
+				},
+			},
+			Swagger: "2.0",
+		},
+	})
+	if err != nil {
+		return fmt.Errorf("error serializing api definitions: %w", err)
+	}
+	os.Stdout.Write(data) // nolint:errcheck
+	return nil
+}
+`

--- a/pkg/controller-gen/main.go
+++ b/pkg/controller-gen/main.go
@@ -1,9 +1,11 @@
 package controllergen
 
 import (
+	"errors"
 	"fmt"
 	"io"
 	"os"
+	"os/exec"
 	"path/filepath"
 	"sort"
 	"strings"
@@ -18,8 +20,9 @@ import (
 	"github.com/sirupsen/logrus"
 	"golang.org/x/tools/imports"
 	"k8s.io/apimachinery/pkg/runtime/schema"
+	acargs "k8s.io/code-generator/cmd/applyconfiguration-gen/args"
+	ac "k8s.io/code-generator/cmd/applyconfiguration-gen/generators"
 	csargs "k8s.io/code-generator/cmd/client-gen/args"
-
 	cs "k8s.io/code-generator/cmd/client-gen/generators"
 	types2 "k8s.io/code-generator/cmd/client-gen/types"
 	dpargs "k8s.io/code-generator/cmd/deepcopy-gen/args"
@@ -28,7 +31,6 @@ import (
 	inf "k8s.io/code-generator/cmd/informer-gen/generators"
 	lsargs "k8s.io/code-generator/cmd/lister-gen/args"
 	ls "k8s.io/code-generator/cmd/lister-gen/generators"
-	oaargs "k8s.io/kube-openapi/cmd/openapi-gen/args"
 	oa "k8s.io/kube-openapi/pkg/generators"
 )
 
@@ -136,6 +138,10 @@ func Run(opts cgargs.Options) {
 		logrus.Fatalf("openapi failed: %v", err)
 	}
 
+	if err := generateApplyConfiguration(groups, customArgs); err != nil {
+		logrus.Fatalf("applyconfiguration failed: %v", err)
+	}
+
 	if err := copyGoPathToModules(customArgs); err != nil {
 		logrus.Fatalf("go modules copy failed: %v", err)
 	}
@@ -234,6 +240,65 @@ func generateDeepcopy(groups map[string]bool, customArgs *cgargs.CustomArgs) err
 	)
 }
 
+func generateApplyConfiguration(groups map[string]bool, customArgs *cgargs.CustomArgs) error {
+	if len(groups) == 0 {
+		return nil
+	}
+	applyconfigurationArgs := acargs.New()
+	applyconfigurationArgs.OutputDir = filepath.Join(customArgs.OutputBase, customArgs.Package, "applyconfiguration")
+	applyconfigurationArgs.OutputPkg = filepath.Join(customArgs.Package, "applyconfiguration")
+	applyconfigurationArgs.GoHeaderFile = customArgs.Options.Boilerplate
+
+	if path, err := generateOpenAPISchemaFile(customArgs); err != nil {
+		logrus.Warnf("%v: fake ClientSet will not be usable - see https://github.com/kubernetes/kubernetes/issues/126850", err)
+	} else {
+		applyconfigurationArgs.OpenAPISchemaFilePath = path
+	}
+
+	inputDirs := []string{}
+	for gv, names := range customArgs.TypesByGroup {
+		if !groups[gv.Group] {
+			continue
+		}
+		inputDirs = append(inputDirs, names[0].Package)
+	}
+
+	getTargets := func(context *generator.Context) []generator.Target {
+		return ac.GetTargets(context, applyconfigurationArgs)
+	}
+
+	return gengo.Execute(
+		ac.NameSystems(),
+		ac.DefaultNameSystem(),
+		getTargets,
+		gengo.StdBuildTag,
+		inputDirs,
+	)
+}
+
+func generateOpenAPISchemaFile(customArgs *cgargs.CustomArgs) (string, error) {
+	modelsSchemaGo := filepath.Join(customArgs.OutputBase, customArgs.Options.OutputPackage, "openapi", "cmd", "models-schema", "main.go")
+	if _, err := os.Stat(modelsSchemaGo); err != nil {
+		return "", errors.New("OpenAPI models-schema command not found; please enable GenerateOpenAPI for one or groups")
+	}
+
+	cmd := exec.Command("go", "run", modelsSchemaGo)
+	cmd.Dir = strings.TrimSuffix(filepath.Join(customArgs.OutputBase, customArgs.Options.OutputPackage), "pkg/generated")
+	cmd.Stderr = os.Stderr
+
+	for _, file := range []string{"go.mod", "go.sum"} {
+		copyFile(file, filepath.Join(cmd.Dir, file))
+	}
+
+	output, err := cmd.Output()
+	if err != nil {
+		return "", fmt.Errorf("failed to run models-schema command: %w", err)
+	}
+
+	schemaFilePath := filepath.Join(customArgs.OutputBase, "schemas.json")
+	return schemaFilePath, os.WriteFile(schemaFilePath, output, 0644)
+}
+
 func generateClientset(groups map[string]bool, customArgs *cgargs.CustomArgs) error {
 	if len(groups) == 0 {
 		return nil
@@ -243,6 +308,7 @@ func generateClientset(groups map[string]bool, customArgs *cgargs.CustomArgs) er
 	clientSetArgs.ClientsetName = "versioned"
 	clientSetArgs.OutputDir = filepath.Join(customArgs.OutputBase, customArgs.Package, "clientset")
 	clientSetArgs.OutputPkg = filepath.Join(customArgs.Package, "clientset")
+	clientSetArgs.ApplyConfigurationPackage = filepath.Join(customArgs.Package, "applyconfiguration")
 	clientSetArgs.GoHeaderFile = customArgs.Options.Boilerplate
 
 	var order []schema.GroupVersion
@@ -293,17 +359,6 @@ func generateOpenAPI(groups map[string]bool, customArgs *cgargs.CustomArgs) erro
 		return nil
 	}
 
-	openAPIArgs := oaargs.New()
-	openAPIArgs.OutputDir = filepath.Join(customArgs.OutputBase, customArgs.Options.OutputPackage, "openapi")
-	openAPIArgs.OutputFile = "zz_generated_openapi.go"
-	openAPIArgs.OutputPkg = customArgs.Options.OutputPackage + "/openapi"
-	openAPIArgs.GoHeaderFile = customArgs.Options.Boilerplate
-	openAPIArgs.OutputModelNameFile = "zz_generated.model_name.go"
-
-	if err := openAPIArgs.Validate(); err != nil {
-		return err
-	}
-
 	inputDirsMap := map[string]bool{}
 	inputDirs := []string{}
 	inputModelDirsMap := map[string]bool{}
@@ -332,13 +387,10 @@ func generateOpenAPI(groups map[string]bool, customArgs *cgargs.CustomArgs) erro
 		}
 	}
 
-	boilerplate, err := gengo.GoBoilerplate(openAPIArgs.GoHeaderFile, gengo.StdBuildTag, gengo.StdGeneratedBy)
-	if err != nil {
-		return err
-	}
+	openAPIGen := generators.NewOpenAPIGenerator()
 
 	getTargets := func(context *generator.Context) []generator.Target {
-		return oa.GetOpenAPITargets(context, openAPIArgs, boilerplate)
+		return openAPIGen.GetOpenAPITargets(context, customArgs)
 	}
 
 	if err := gengo.Execute(
@@ -356,7 +408,7 @@ func generateOpenAPI(groups map[string]bool, customArgs *cgargs.CustomArgs) erro
 	}
 
 	getModelNameTargets := func(context *generator.Context) []generator.Target {
-		return oa.GetModelNameTargets(context, openAPIArgs, boilerplate)
+		return openAPIGen.GetModelNameTargets(context, customArgs)
 	}
 
 	return gengo.Execute(


### PR DESCRIPTION
Wrangler's code-gen helpers do not currently enable support for field management (server-side apply) in clients. In order to do this, we need to generate applyconfiguration code, and reference it when generating the clients.
* Ref: https://github.com/kubernetes/kubernetes/pull/125560

Fake NewClientset requires OpenAPI types to function properly; without
OpenAPI type generation enabled only NewSimpleClientset is usable for
custom types.
* Ref: https://github.com/kubernetes/kubernetes/issues/126850

Server-side apply has been stable since 1.22 so we are somewhat behind on supporting it:
* https://kubernetes.io/docs/reference/using-api/server-side-apply/
* https://pkg.go.dev/k8s.io/client-go/applyconfigurations