### PR TITLE
Add WithNullSafePatch for applying explicit nulls to CRDs

### DIFF
--- a/pkg/apply/apply.go
+++ b/pkg/apply/apply.go
@@ -82,6 +82,7 @@ type Apply interface {
 	WithSetOwnerReference(controller, block bool) Apply
 	WithIgnorePreviousApplied() Apply
 	WithDiffPatch(gvk schema.GroupVersionKind, namespace, name string, patch []byte) Apply
+	WithNullSafePatch(gvks ...schema.GroupVersionKind) Apply
 
 	FindOwner(obj runtime.Object) (runtime.Object, error)
 	PurgeOrphan(obj runtime.Object) error
@@ -250,6 +251,10 @@ func (a *apply) WithPatcher(gvk schema.GroupVersionKind, patcher Patcher) Apply 
 
 func (a *apply) WithReconciler(gvk schema.GroupVersionKind, reconciler Reconciler) Apply {
 	return a.newDesiredSet().WithReconciler(gvk, reconciler)
+}
+
+func (a *apply) WithNullSafePatch(gvks ...schema.GroupVersionKind) Apply {
+	return a.newDesiredSet().WithNullSafePatch(gvks...)
 }
 
 func (a *apply) WithStrictCaching() Apply {

--- a/pkg/apply/desiredset.go
+++ b/pkg/apply/desiredset.go
@@ -39,6 +39,7 @@ type desiredSet struct {
 	pruneTypes               map[schema.GroupVersionKind]cache.SharedIndexInformer
 	patchers                 map[schema.GroupVersionKind]Patcher
 	reconcilers              map[schema.GroupVersionKind]Reconciler
+	nullSafePatch            map[schema.GroupVersionKind]struct{}
 	diffPatches              map[patchKey][][]byte
 	informerFactory          InformerFactory
 	remove                   bool
@@ -218,6 +219,18 @@ func (o desiredSet) WithReconciler(gvk schema.GroupVersionKind, reconciler Recon
 	}
 	reconcilers[gvk] = reconciler
 	o.reconcilers = reconcilers
+	return o
+}
+
+func (o desiredSet) WithNullSafePatch(gvks ...schema.GroupVersionKind) Apply {
+	nullSafe := map[schema.GroupVersionKind]struct{}{}
+	for k, v := range o.nullSafePatch {
+		nullSafe[k] = v
+	}
+	for _, gvk := range gvks {
+		nullSafe[gvk] = struct{}{}
+	}
+	o.nullSafePatch = nullSafe
 	return o
 }
 

--- a/pkg/apply/desiredset_compare.go
+++ b/pkg/apply/desiredset_compare.go
@@ -131,6 +131,13 @@ func emptyMaps(data map[string]interface{}, keys ...string) bool {
 }
 
 func sanitizePatch(patch []byte, removeObjectSetAnnotation bool) ([]byte, error) {
+	if patch2.IsJSONPatch(patch) {
+		if !removeObjectSetAnnotation {
+			return patch, nil
+		}
+		return dropObjectSetOps(patch)
+	}
+
 	mod := false
 	data := map[string]interface{}{}
 	err := json.Unmarshal(patch, &data)
@@ -185,7 +192,31 @@ func sanitizePatch(patch []byte, removeObjectSetAnnotation bool) ([]byte, error)
 	return json.Marshal(data)
 }
 
-func applyPatch(gvk schema.GroupVersionKind, reconciler Reconciler, patcher Patcher, debugID string, ignoreOriginal bool, oldObject, newObject runtime.Object, diffPatches [][]byte) (bool, error) {
+// objectSetOpPrefix is the JSON Pointer prefix of the operations that carry
+// apply's own bookkeeping annotations.
+var objectSetOpPrefix = "/metadata/annotations/" + patch2.EscapePointerToken(LabelPrefix)
+
+func dropObjectSetOps(patch []byte) ([]byte, error) {
+	var ops []patch2.Operation
+	if err := json.Unmarshal(patch, &ops); err != nil {
+		return nil, err
+	}
+
+	kept := make([]patch2.Operation, 0, len(ops))
+	for _, op := range ops {
+		if !strings.HasPrefix(op.Path, objectSetOpPrefix) {
+			kept = append(kept, op)
+		}
+	}
+
+	if len(kept) == 0 {
+		return []byte("[]"), nil
+	}
+
+	return json.Marshal(kept)
+}
+
+func applyPatch(gvk schema.GroupVersionKind, reconciler Reconciler, patcher Patcher, debugID string, ignoreOriginal, nullSafe bool, oldObject, newObject runtime.Object, diffPatches [][]byte) (bool, error) {
 	oldMetadata, err := meta.Accessor(oldObject)
 	if err != nil {
 		return false, err
@@ -221,6 +252,25 @@ func applyPatch(gvk schema.GroupVersionKind, reconciler Reconciler, patcher Patc
 
 	if string(patch) == "{}" {
 		return false, nil
+	}
+
+	if nullSafe && patchType == types.MergePatchType {
+		// doPatch generates the merge patch from the ignore-stripped documents,
+		// so the translation has to resolve nulls against those same ones or a
+		// wholesale subtree reinstates a field an ignore patch took out.
+		_, strippedModified, strippedCurrent, err := stripIgnores(nil, modified, current, diffPatches)
+		if err != nil {
+			return false, err
+		}
+
+		patch, err = patch2.CreateJSONPatchFromMergePatch(patch, strippedModified, strippedCurrent)
+		if err != nil {
+			return false, fmt.Errorf("json patch generation: %w", err)
+		}
+		patchType = types.JSONPatchType
+		if string(patch) == "[]" {
+			return false, nil
+		}
 	}
 
 	logrus.Debugf("DesiredSet - Patch %s %s/%s for %s -- [PATCH:%s, ORIGINAL:%s, MODIFIED:%s, CURRENT:%s]", gvk, oldMetadata.GetNamespace(), oldMetadata.GetName(), debugID, patch, original, modified, current)
@@ -272,7 +322,9 @@ func (o *desiredSet) compareObjects(gvk schema.GroupVersionKind, reconciler Reco
 		GroupVersionKind: gvk,
 	}]...)
 
-	if ran, err := applyPatch(gvk, reconciler, patcher, debugID, o.ignorePreviousApplied, oldObject, newObject, diffPatches); err != nil {
+	_, nullSafe := o.nullSafePatch[gvk]
+
+	if ran, err := applyPatch(gvk, reconciler, patcher, debugID, o.ignorePreviousApplied, nullSafe, oldObject, newObject, diffPatches); err != nil {
 		return err
 	} else if !ran {
 		logrus.Debugf("DesiredSet - No change(2) %s %s/%s for %s", gvk, oldMetadata.GetNamespace(), oldMetadata.GetName(), debugID)

--- a/pkg/apply/desiredset_compare_test.go
+++ b/pkg/apply/desiredset_compare_test.go
@@ -3,6 +3,17 @@ package apply
 import (
 	"bytes"
 	"testing"
+
+	data2 "github.com/rancher/wrangler/v3/pkg/data"
+	"github.com/rancher/wrangler/v3/pkg/data/convert"
+	patch2 "github.com/rancher/wrangler/v3/pkg/patch"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/apimachinery/pkg/util/json"
 )
 
 func TestCompressAndEncode(t *testing.T) {
@@ -39,6 +50,235 @@ func TestCompressAndEncode(t *testing.T) {
 			if got, want := compressAndEncode(tc.input), tc.expected; got != want {
 				t.Errorf("got %q, want %q", got, want)
 			}
+		})
+	}
+}
+
+var nullSafeGVK = schema.GroupVersionKind{Group: "rke.cattle.io", Version: "v1", Kind: "RKEControlPlane"}
+
+// spec builds an object of a kind absent from the client-go scheme, which is
+// what makes apply reach for a merge patch.
+func spec(gvk schema.GroupVersionKind, spec map[string]interface{}) *unstructured.Unstructured {
+	apiVersion, kind := gvk.ToAPIVersionAndKind()
+	return &unstructured.Unstructured{
+		Object: map[string]interface{}{
+			"apiVersion": apiVersion,
+			"kind":       kind,
+			"metadata": map[string]interface{}{
+				"name":      "cluster",
+				"namespace": "fleet-default",
+			},
+			"spec": spec,
+		},
+	}
+}
+
+func chartValues(gvk schema.GroupVersionKind, values map[string]interface{}) *unstructured.Unstructured {
+	return spec(gvk, map[string]interface{}{"chartValues": values})
+}
+
+// applied returns obj as the server would hold it after apply created it,
+// carrying the annotation the next patch is generated against.
+func applied(t *testing.T, gvk schema.GroupVersionKind, obj *unstructured.Unstructured) runtime.Object {
+	t.Helper()
+	prepared, err := prepareObjectForCreate(gvk, obj)
+	require.NoError(t, err)
+	return prepared
+}
+
+// patchedChartValues applies patch to current the way the apiserver would and
+// returns the resulting spec.chartValues, along with whether "b" is present at
+// all -- a removal and an assignment of null both decode to nil.
+func patchedChartValues(t *testing.T, current runtime.Object, patch []byte) (map[string]interface{}, bool) {
+	t.Helper()
+
+	currentJSON, err := json.Marshal(current)
+	require.NoError(t, err)
+
+	result, err := patch2.Apply(currentJSON, patch)
+	require.NoError(t, err)
+
+	obj := map[string]interface{}{}
+	require.NoError(t, json.Unmarshal(result, &obj))
+
+	values := convert.ToMapInterface(data2.GetValueN(obj, "spec", "chartValues"))
+	_, ok := values["b"]
+
+	return values, ok
+}
+
+// capturePatch runs applyPatch against a patcher that records what it was
+// handed rather than sending it.
+func capturePatch(t *testing.T, gvk schema.GroupVersionKind, nullSafe bool, current, desired runtime.Object, diffPatches ...[]byte) (types.PatchType, []byte, bool) {
+	t.Helper()
+
+	var (
+		gotType  types.PatchType
+		gotPatch []byte
+	)
+
+	ran, err := applyPatch(gvk, nil, func(namespace, name string, pt types.PatchType, data []byte) (runtime.Object, error) {
+		gotType, gotPatch = pt, data
+		return nil, nil
+	}, "test", false, nullSafe, current, desired, diffPatches)
+	require.NoError(t, err)
+
+	return gotType, gotPatch, ran
+}
+
+func TestApplyPatchNullSafe(t *testing.T) {
+	// The desired state removes a chart default by setting it to null, which is
+	// the case a merge patch cannot express.
+	current := applied(t, nullSafeGVK, chartValues(nullSafeGVK, map[string]interface{}{"a": "1", "b": "2"}))
+	desired := chartValues(nullSafeGVK, map[string]interface{}{"a": "1", "b": nil})
+
+	t.Run("merge patch drops the null", func(t *testing.T) {
+		patchType, patch, ran := capturePatch(t, nullSafeGVK, false, current, desired)
+		require.True(t, ran)
+		assert.Equal(t, types.MergePatchType, patchType)
+
+		values, hasB := patchedChartValues(t, current, patch)
+		assert.False(t, hasB, "merge patch removed the key instead of setting it to null")
+		assert.Equal(t, "1", values["a"])
+	})
+
+	t.Run("null safe patch keeps the null", func(t *testing.T) {
+		patchType, patch, ran := capturePatch(t, nullSafeGVK, true, current, desired)
+		require.True(t, ran)
+		assert.Equal(t, types.JSONPatchType, patchType)
+
+		values, hasB := patchedChartValues(t, current, patch)
+		assert.True(t, hasB, "the key is gone, so the null was not applied")
+		assert.Nil(t, values["b"])
+		assert.Equal(t, "1", values["a"])
+	})
+
+	t.Run("null safe patch is equivalent when no null is involved", func(t *testing.T) {
+		desired := chartValues(nullSafeGVK, map[string]interface{}{"a": "2", "b": "2"})
+
+		mergeType, mergePatch, ran := capturePatch(t, nullSafeGVK, false, current, desired)
+		require.True(t, ran)
+		require.Equal(t, types.MergePatchType, mergeType)
+
+		jsonType, jsonPatch, ran := capturePatch(t, nullSafeGVK, true, current, desired)
+		require.True(t, ran)
+		require.Equal(t, types.JSONPatchType, jsonType)
+
+		merged, err := patch2.Apply(mustMarshal(t, current), mergePatch)
+		require.NoError(t, err)
+		patched, err := patch2.Apply(mustMarshal(t, current), jsonPatch)
+		require.NoError(t, err)
+
+		assert.JSONEq(t, string(merged), string(patched))
+	})
+
+	t.Run("no change sends nothing", func(t *testing.T) {
+		_, _, ran := capturePatch(t, nullSafeGVK, true, current, chartValues(nullSafeGVK, map[string]interface{}{"a": "1", "b": "2"}))
+		assert.False(t, ran)
+	})
+
+	t.Run("an ignored field is not reinstated by a wholesale add", func(t *testing.T) {
+		// The subtree is missing from current, so it is set from modified in one
+		// operation -- which has to be the modified the merge patch was
+		// generated from, with the ignored field already taken out of it.
+		current := applied(t, nullSafeGVK, spec(nullSafeGVK, map[string]interface{}{}))
+		desired := chartValues(nullSafeGVK, map[string]interface{}{"a": "1", "ignored": "x"})
+		ignore := []byte(`[{"op":"remove","path":"/spec/chartValues/ignored"}]`)
+
+		_, patch, ran := capturePatch(t, nullSafeGVK, true, current, desired, ignore)
+		require.True(t, ran)
+
+		values, _ := patchedChartValues(t, current, patch)
+		assert.Equal(t, map[string]interface{}{"a": "1"}, values)
+	})
+
+	t.Run("strategic merge is left alone", func(t *testing.T) {
+		// Strategic merge has its own directives for a null assignment, and it
+		// is only reachable for types in the client-go scheme.
+		gvk := schema.GroupVersionKind{Version: "v1", Kind: "ConfigMap"}
+		current := applied(t, gvk, configMap(gvk, map[string]interface{}{"a": "1"}))
+		desired := configMap(gvk, map[string]interface{}{"a": "2"})
+
+		patchType, _, ran := capturePatch(t, gvk, true, current, desired)
+		require.True(t, ran)
+		assert.Equal(t, types.StrategicMergePatchType, patchType)
+	})
+}
+
+func configMap(gvk schema.GroupVersionKind, data map[string]interface{}) *unstructured.Unstructured {
+	apiVersion, kind := gvk.ToAPIVersionAndKind()
+	return &unstructured.Unstructured{
+		Object: map[string]interface{}{
+			"apiVersion": apiVersion,
+			"kind":       kind,
+			"metadata": map[string]interface{}{
+				"name":      "config",
+				"namespace": "default",
+			},
+			"data": data,
+		},
+	}
+}
+
+func mustMarshal(t *testing.T, obj runtime.Object) []byte {
+	t.Helper()
+	b, err := json.Marshal(obj)
+	require.NoError(t, err)
+	return b
+}
+
+func TestSanitizePatchJSONPatch(t *testing.T) {
+	tests := []struct {
+		name                      string
+		patch                     string
+		removeObjectSetAnnotation bool
+		expected                  string
+	}{
+		{
+			name:     "a json patch is passed through untouched",
+			patch:    `[{"op":"add","path":"/spec/chartValues/b","value":null}]`,
+			expected: `[{"op":"add","path":"/spec/chartValues/b","value":null}]`,
+		},
+		{
+			name:                      "the applied annotation is dropped from a plan",
+			patch:                     `[{"op":"add","path":"/metadata/annotations/objectset.rio.cattle.io~1applied","value":"x"},{"op":"add","path":"/spec/a","value":"1"}]`,
+			removeObjectSetAnnotation: true,
+			expected:                  `[{"op":"add","path":"/spec/a","value":"1"}]`,
+		},
+		{
+			name:                      "a patch carrying only the applied annotation is empty",
+			patch:                     `[{"op":"add","path":"/metadata/annotations/objectset.rio.cattle.io~1applied","value":"x"}]`,
+			removeObjectSetAnnotation: true,
+			expected:                  `[]`,
+		},
+		{
+			name: "a whole annotations map is left alone",
+			// Only reachable when apply adopts an object that has no
+			// annotations at all, where a plan naming the annotation is a
+			// cosmetic wart rather than a wrong plan.
+			patch:                     `[{"op":"add","path":"/metadata/annotations","value":{"objectset.rio.cattle.io/applied":"x"}}]`,
+			removeObjectSetAnnotation: true,
+			expected:                  `[{"op":"add","path":"/metadata/annotations","value":{"objectset.rio.cattle.io/applied":"x"}}]`,
+		},
+		{
+			name:                      "a removal of the applied annotation is dropped",
+			patch:                     `[{"op":"remove","path":"/metadata/annotations/objectset.rio.cattle.io~1applied"}]`,
+			removeObjectSetAnnotation: true,
+			expected:                  `[]`,
+		},
+		{
+			name:                      "an unrelated annotation is kept",
+			patch:                     `[{"op":"add","path":"/metadata/annotations/other.io~1thing","value":"x"}]`,
+			removeObjectSetAnnotation: true,
+			expected:                  `[{"op":"add","path":"/metadata/annotations/other.io~1thing","value":"x"}]`,
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			got, err := sanitizePatch([]byte(test.patch), test.removeObjectSetAnnotation)
+			require.NoError(t, err)
+			assert.Equal(t, test.expected, string(got))
 		})
 	}
 }

--- a/pkg/apply/desiredset_process.go
+++ b/pkg/apply/desiredset_process.go
@@ -272,7 +272,7 @@ func (o *desiredSet) process(debugID string, set labels.Selector, gvk schema.Gro
 			if err != nil {
 				return nil, err
 			}
-			if string(data) != "{}" {
+			if string(data) != "{}" && string(data) != "[]" {
 				o.plan.Update.Add(gvk, namespace, name, string(data))
 			}
 			return nil, nil

--- a/pkg/apply/fake/apply.go
+++ b/pkg/apply/fake/apply.go
@@ -65,6 +65,10 @@ func (f *FakeApply) WithReconciler(gvk schema.GroupVersionKind, reconciler apply
 	return f
 }
 
+func (f *FakeApply) WithNullSafePatch(gvks ...schema.GroupVersionKind) apply.Apply {
+	return f
+}
+
 func (f *FakeApply) WithStrictCaching() apply.Apply {
 	return f
 }

--- a/pkg/patch/jsonpatch.go
+++ b/pkg/patch/jsonpatch.go
@@ -1,0 +1,162 @@
+package patch
+
+import (
+	"encoding/json"
+	"fmt"
+	"sort"
+	"strings"
+)
+
+// pointerEscaper implements RFC 6901 JSON Pointer token escaping. "~" is listed
+// first so that the "0" it introduces is not itself rewritten.
+var pointerEscaper = strings.NewReplacer("~", "~0", "/", "~1")
+
+// EscapePointerToken escapes a single JSON Pointer reference token per RFC 6901.
+func EscapePointerToken(token string) string {
+	return pointerEscaper.Replace(token)
+}
+
+// IsJSONPatch reports whether the given bytes are an RFC 6902 JSON Patch, which
+// is a list, as opposed to a merge patch, which is an object.
+func IsJSONPatch(patch []byte) bool {
+	return isJSONPatch(patch)
+}
+
+// Operation is a single RFC 6902 JSON Patch operation.
+//
+// Value is a pointer so that a literal null can be distinguished from an absent
+// value: "remove" carries no value member, while assigning null requires one.
+type Operation struct {
+	Op    string           `json:"op"`
+	Path  string           `json:"path"`
+	Value *json.RawMessage `json:"value,omitempty"`
+}
+
+func addOp(path string, v interface{}) (Operation, error) {
+	b, err := json.Marshal(v)
+	if err != nil {
+		return Operation{}, fmt.Errorf("marshalling value for %s: %w", path, err)
+	}
+	raw := json.RawMessage(b)
+	// RFC 6902 "add" on an object member creates the member or replaces its
+	// value, so it is correct whether or not the key already exists. "replace"
+	// would fail on a missing target.
+	return Operation{Op: "add", Path: path, Value: &raw}, nil
+}
+
+// CreateJSONPatchFromMergePatch translates an RFC 7386 JSON merge patch into an
+// equivalent RFC 6902 JSON Patch.
+//
+// A null in a merge patch is ambiguous. RFC 7386 defines it as an instruction to
+// remove a key, so a caller cannot use one to set a value to null -- which makes
+// an explicit null inexpressible against any resource patched with
+// types.MergePatchType, and that is every CRD. RFC 6902 draws the distinction
+// the merge format cannot: "remove" and "add" with a null value are different
+// operations.
+//
+// The ambiguity is resolved against modified, the desired object the merge patch
+// was generated from. A null at a path that is explicitly null in modified is an
+// assignment; a null at a path absent from modified is a removal.
+//
+// current, the live object, is used to drop removals of paths that do not exist,
+// because RFC 6902 requires "remove" to target an existing path and fails the
+// entire patch otherwise.
+//
+// Everything the merge patch would have done is preserved. Arrays are treated as
+// opaque leaves and replaced wholesale, matching merge patch semantics and
+// keeping positional index operations -- and the races that come with them --
+// out of the result.
+func CreateJSONPatchFromMergePatch(mergePatch, modified, current []byte) ([]byte, error) {
+	var mp, mod, cur map[string]interface{}
+	if err := json.Unmarshal(mergePatch, &mp); err != nil {
+		return nil, fmt.Errorf("unmarshalling merge patch: %w", err)
+	}
+	if err := json.Unmarshal(modified, &mod); err != nil {
+		return nil, fmt.Errorf("unmarshalling modified: %w", err)
+	}
+	if err := json.Unmarshal(current, &cur); err != nil {
+		return nil, fmt.Errorf("unmarshalling current: %w", err)
+	}
+
+	ops := []Operation{}
+
+	var walk func(patch, modNode, curNode map[string]interface{}, path string) error
+	walk = func(patch, modNode, curNode map[string]interface{}, path string) error {
+		// Sorted so that the generated patch is deterministic, which keeps debug
+		// logs and tests stable. Ordering is not required for correctness: an
+		// operation is emitted either for a node or for its descendants, never
+		// for both, so no two operations overlap.
+		keys := make([]string, 0, len(patch))
+		for k := range patch {
+			keys = append(keys, k)
+		}
+		sort.Strings(keys)
+
+		for _, k := range keys {
+			v := patch[k]
+			p := path + "/" + EscapePointerToken(k)
+			modChild, modHas := modNode[k]
+			curChild, curHas := curNode[k]
+
+			if v == nil {
+				switch {
+				case modHas && modChild == nil:
+					// The desired object asks for a literal null. This is the
+					// case a merge patch cannot express.
+					op, err := addOp(p, nil)
+					if err != nil {
+						return err
+					}
+					ops = append(ops, op)
+				case curHas:
+					ops = append(ops, Operation{Op: "remove", Path: p})
+				}
+				// A removal of something that is not in current is a no-op and
+				// would fail the patch, so nothing is emitted.
+				continue
+			}
+
+			if patchChild, ok := v.(map[string]interface{}); ok {
+				curMap, curIsMap := curChild.(map[string]interface{})
+				modMap, modIsMap := modChild.(map[string]interface{})
+				if curHas && curIsMap && modIsMap {
+					// Recursing only where current already holds an object
+					// guarantees the parent of every emitted path exists, which
+					// is what RFC 6902 "add" requires.
+					if err := walk(patchChild, modMap, curMap, p); err != nil {
+						return err
+					}
+					continue
+				}
+
+				// Nothing mergeable underneath, so the subtree is set wholesale.
+				// The value is taken from modified rather than from the patch so
+				// that any nulls it carries are assignments, not stale removals
+				// against a path that does not exist.
+				value := interface{}(patchChild)
+				if modHas {
+					value = modChild
+				}
+				op, err := addOp(p, value)
+				if err != nil {
+					return err
+				}
+				ops = append(ops, op)
+				continue
+			}
+
+			op, err := addOp(p, v)
+			if err != nil {
+				return err
+			}
+			ops = append(ops, op)
+		}
+		return nil
+	}
+
+	if err := walk(mp, mod, cur, ""); err != nil {
+		return nil, err
+	}
+
+	return json.Marshal(ops)
+}

--- a/pkg/patch/jsonpatch_test.go
+++ b/pkg/patch/jsonpatch_test.go
@@ -1,0 +1,214 @@
+package patch
+
+import (
+	"encoding/json"
+	"sort"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestEscapePointerToken(t *testing.T) {
+	tests := []struct {
+		name    string
+		token   string
+		escaped string
+	}{
+		{name: "no reserved character", token: "chartValues", escaped: "chartValues"},
+		{name: "slash", token: "objectset.rio.cattle.io/applied", escaped: "objectset.rio.cattle.io~1applied"},
+		{name: "tilde", token: "a~b", escaped: "a~0b"},
+		{name: "tilde before one", token: "a~1b", escaped: "a~01b"},
+		{name: "both", token: "a~/b", escaped: "a~0~1b"},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			assert.Equal(t, test.escaped, EscapePointerToken(test.token))
+		})
+	}
+}
+
+func TestIsJSONPatch(t *testing.T) {
+	assert.True(t, IsJSONPatch([]byte(`[{"op":"remove","path":"/spec"}]`)))
+	assert.False(t, IsJSONPatch([]byte(`{"spec":null}`)))
+	assert.False(t, IsJSONPatch(nil))
+}
+
+func TestCreateJSONPatchFromMergePatch(t *testing.T) {
+	tests := []struct {
+		name string
+		// mergePatch is what apply sends today, and the three-way merge that
+		// produced it is what loses the null.
+		mergePatch string
+		modified   string
+		current    string
+		// expected is the translated patch, whose operations are sorted by path
+		// within each object.
+		expected string
+		// patched is current with expected applied, and is what the caller
+		// actually asked for.
+		patched string
+	}{
+		{
+			name:       "explicit null is assigned rather than removed",
+			mergePatch: `{"spec":{"chartValues":{"b":null}}}`,
+			modified:   `{"spec":{"chartValues":{"a":"1","b":null}}}`,
+			current:    `{"spec":{"chartValues":{"a":"1","b":"2"}}}`,
+			expected:   `[{"op":"add","path":"/spec/chartValues/b","value":null}]`,
+			patched:    `{"spec":{"chartValues":{"a":"1","b":null}}}`,
+		},
+		{
+			name:       "null for a key absent from modified is a removal",
+			mergePatch: `{"spec":{"chartValues":{"b":null}}}`,
+			modified:   `{"spec":{"chartValues":{"a":"1"}}}`,
+			current:    `{"spec":{"chartValues":{"a":"1","b":"2"}}}`,
+			expected:   `[{"op":"remove","path":"/spec/chartValues/b"}]`,
+			patched:    `{"spec":{"chartValues":{"a":"1"}}}`,
+		},
+		{
+			name: "removal of a key absent from current emits nothing",
+			// RFC 6902 fails the whole patch on a remove of a missing path,
+			// where the merge patch it came from was a no-op.
+			mergePatch: `{"spec":{"chartValues":{"b":null}}}`,
+			modified:   `{"spec":{"chartValues":{"a":"1"}}}`,
+			current:    `{"spec":{"chartValues":{"a":"1"}}}`,
+			expected:   `[]`,
+			patched:    `{"spec":{"chartValues":{"a":"1"}}}`,
+		},
+		{
+			name:       "empty merge patch",
+			mergePatch: `{}`,
+			modified:   `{"spec":{"chartValues":{"a":"1"}}}`,
+			current:    `{"spec":{"chartValues":{"a":"1"}}}`,
+			expected:   `[]`,
+			patched:    `{"spec":{"chartValues":{"a":"1"}}}`,
+		},
+		{
+			name:       "pointer tokens are escaped",
+			mergePatch: `{"metadata":{"annotations":{"a/b":"x","c~d":null}}}`,
+			modified:   `{"metadata":{"annotations":{"a/b":"x","c~d":null}}}`,
+			current:    `{"metadata":{"annotations":{"a/b":"1","c~d":"2"}}}`,
+			expected:   `[{"op":"add","path":"/metadata/annotations/a~1b","value":"x"},{"op":"add","path":"/metadata/annotations/c~0d","value":null}]`,
+			patched:    `{"metadata":{"annotations":{"a/b":"x","c~d":null}}}`,
+		},
+		{
+			name:       "arrays are replaced wholesale",
+			mergePatch: `{"spec":{"list":[3]}}`,
+			modified:   `{"spec":{"list":[3]}}`,
+			current:    `{"spec":{"list":[1,2,3]}}`,
+			expected:   `[{"op":"add","path":"/spec/list","value":[3]}]`,
+			patched:    `{"spec":{"list":[3]}}`,
+		},
+		{
+			name: "subtree missing from current is added wholesale with its nulls",
+			// The parent of every emitted path has to exist, so the walk stops
+			// at the deepest object current holds.
+			mergePatch: `{"spec":{"chartValues":{"a":null}}}`,
+			modified:   `{"spec":{"chartValues":{"a":null}}}`,
+			current:    `{"spec":{}}`,
+			expected:   `[{"op":"add","path":"/spec/chartValues","value":{"a":null}}]`,
+			patched:    `{"spec":{"chartValues":{"a":null}}}`,
+		},
+		{
+			name: "stale removal inside a new subtree is dropped",
+			// The subtree value comes from modified, not from the merge patch,
+			// so a removal of a key that never reaches the server is not
+			// written out as a null.
+			mergePatch: `{"spec":{"chartValues":{"a":"1","b":null}}}`,
+			modified:   `{"spec":{"chartValues":{"a":"1"}}}`,
+			current:    `{"spec":{}}`,
+			expected:   `[{"op":"add","path":"/spec/chartValues","value":{"a":"1"}}]`,
+			patched:    `{"spec":{"chartValues":{"a":"1"}}}`,
+		},
+		{
+			name:       "object replacing a scalar is set wholesale",
+			mergePatch: `{"spec":{"x":{"y":1}}}`,
+			modified:   `{"spec":{"x":{"y":1}}}`,
+			current:    `{"spec":{"x":"str"}}`,
+			expected:   `[{"op":"add","path":"/spec/x","value":{"y":1}}]`,
+			patched:    `{"spec":{"x":{"y":1}}}`,
+		},
+		{
+			name:       "operations are emitted in a stable order",
+			mergePatch: `{"spec":{"c":"3","a":"1","b":null},"metadata":{"name":"n"}}`,
+			modified:   `{"metadata":{"name":"n"},"spec":{"a":"1","b":null,"c":"3"}}`,
+			current:    `{"metadata":{"name":"o"},"spec":{"a":"0","b":"2","c":"0"}}`,
+			expected: `[{"op":"add","path":"/metadata/name","value":"n"},` +
+				`{"op":"add","path":"/spec/a","value":"1"},` +
+				`{"op":"add","path":"/spec/b","value":null},` +
+				`{"op":"add","path":"/spec/c","value":"3"}]`,
+			patched: `{"metadata":{"name":"n"},"spec":{"a":"1","b":null,"c":"3"}}`,
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			got, err := CreateJSONPatchFromMergePatch([]byte(test.mergePatch), []byte(test.modified), []byte(test.current))
+			require.NoError(t, err)
+			assert.Equal(t, test.expected, string(got))
+
+			if string(got) == "[]" {
+				// An empty patch is never sent, and evanphx rejects it.
+				assert.JSONEq(t, test.patched, test.current)
+				return
+			}
+
+			// Apply routes on the leading "[", so this exercises the same path
+			// the apiserver takes.
+			patched, err := Apply([]byte(test.current), got)
+			require.NoError(t, err)
+			assert.JSONEq(t, test.patched, string(patched))
+
+			// JSONEq compares decoded values, where a null member and an absent
+			// one are both nil, so the distinction this whole translation
+			// exists for needs checking on the bytes.
+			assertSameNullKeys(t, test.patched, string(patched))
+		})
+	}
+}
+
+func TestCreateJSONPatchFromMergePatchInvalidInput(t *testing.T) {
+	valid := []byte(`{"spec":{}}`)
+
+	_, err := CreateJSONPatchFromMergePatch([]byte(`not json`), valid, valid)
+	assert.ErrorContains(t, err, "unmarshalling merge patch")
+
+	_, err = CreateJSONPatchFromMergePatch(valid, []byte(`not json`), valid)
+	assert.ErrorContains(t, err, "unmarshalling modified")
+
+	_, err = CreateJSONPatchFromMergePatch(valid, valid, []byte(`not json`))
+	assert.ErrorContains(t, err, "unmarshalling current")
+}
+
+// assertSameNullKeys checks that the two documents hold explicit nulls at the
+// same paths, which is the difference assert.JSONEq cannot see.
+func assertSameNullKeys(t *testing.T, want, got string) {
+	t.Helper()
+	assert.Equal(t, nullPaths(t, want), nullPaths(t, got), "explicit nulls differ")
+}
+
+func nullPaths(t *testing.T, doc string) []string {
+	t.Helper()
+
+	var data map[string]interface{}
+	require.NoError(t, json.Unmarshal([]byte(doc), &data))
+
+	paths := []string{}
+	var walk func(node map[string]interface{}, path string)
+	walk = func(node map[string]interface{}, path string) {
+		for k, v := range node {
+			p := path + "/" + k
+			switch child := v.(type) {
+			case nil:
+				paths = append(paths, p)
+			case map[string]interface{}:
+				walk(child, p)
+			}
+		}
+	}
+	walk(data, "")
+	sort.Strings(paths)
+
+	return paths
+}


### PR DESCRIPTION
## Problem

`apply` cannot express an explicit `null` on any CRD.

`patch.GetMergeStyle` (`pkg/patch/style.go:59-60`) selects `types.MergePatchType` for
every GVK that is not registered in `k8s.io/client-go/kubernetes/scheme` — which is
every CRD. RFC 7386 defines a `null` member in a merge patch as an instruction to
**remove** the key, not as a value, so a caller that puts a literal `null` in the
desired object cannot get one onto the server.

The loss happens at patch generation, not on the server.
`jsonmergepatch.CreateThreeWayJSONMergePatch` builds the patch in two halves and runs
both through `keepOrDeleteNullInJsonPatch`: the add/change half strips nulls, and the
delete half keeps only nulls. An explicit null is therefore either discarded or turned
into a deletion. There is no error, event, or retry — the caller's intent just
disappears.

Downstream symptom: [rancher/rancher#56335](https://github.com/rancher/rancher/issues/56335).
Setting a Helm value to `null` in `spec.rkeConfig.chartValues` — the documented way to
remove a chart default — is silently dropped, so the generated `HelmChartConfig` never
removes the default.

## Solution

Add an opt-in, per-GVK patch mode that translates the merge patch `apply` already
computed into an equivalent RFC 6902 JSON Patch. RFC 6902 is the only patch format
Kubernetes accepts that distinguishes `{"op":"remove"}` from `{"op":"add","value":null}`.

### New API

```go
// pkg/apply/apply.go
WithNullSafePatch(gvks ...schema.GroupVersionKind) Apply
```

Implemented on `desiredSet` following the copy-on-write shape of the existing
`WithPatcher` / `WithReconciler`, backed by a `nullSafePatch` set on the struct.

### New: `pkg/patch/jsonpatch.go`

```go
func CreateJSONPatchFromMergePatch(mergePatch, modified, current []byte) ([]byte, error)
```

The ambiguity of a null is resolved against `modified`, the desired object the merge
patch was generated from:

| null in merge patch at path | in `modified` | in `current` | emitted |
|---|---|---|---|
| yes | explicitly `null` | — | `{"op":"add","value":null}` — **assignment** |
| yes | absent | present | `{"op":"remove"}` |
| yes | absent | absent | nothing (RFC 6902 `remove` on a missing path fails the whole patch) |

Everything the merge patch would have done is preserved. Supporting details:

- `Operation.Value` is a `*json.RawMessage`, so a literal null is distinguishable from
  an absent value — `remove` carries no `value` member, assigning null requires one.
- `add` rather than `replace`: on an object member RFC 6902 `add` is an upsert, correct
  whether or not the key exists, while `replace` fails on a missing target.
- Recursion only descends where `current` already holds an object, which guarantees the
  parent of every emitted path exists — the precondition RFC 6902 `add` requires.
- Where a subtree is not mergeable it is set wholesale from `modified`, not from the
  patch, so nulls it carries are assignments rather than stale removals.
- Arrays are opaque leaves, replaced wholesale — matches merge-patch semantics and keeps
  positional index ops, and their races, out of the result.
- Keys are walked in sorted order so the output is deterministic for tests and debug
  logs. Ordering is not needed for correctness: an op is emitted for a node or for its
  descendants, never both.

### Call site

One branch in `applyPatch` (`pkg/apply/desiredset_compare.go`), after the patch is
computed and before it is sent:

```go
if nullSafe && patchType == types.MergePatchType {
    _, strippedModified, strippedCurrent, err := stripIgnores(nil, modified, current, diffPatches)
    ...
    patch, err = patch2.CreateJSONPatchFromMergePatch(patch, strippedModified, strippedCurrent)
    patchType = types.JSONPatchType
    if string(patch) == "[]" { return false, nil }
}
```

The translation resolves against the ignore-stripped documents, the same ones `doPatch`
generated the merge patch from — otherwise a wholesale subtree would reinstate a field
an ignore patch had taken out.

### Three places that assumed the patch is a JSON object

1. `sanitizePatch` unmarshalled into a map, which errors on `[...]`. It now early-returns
   for array patches, via `dropObjectSetOps` when the objectset annotation must be
   stripped.
2. The empty-patch sentinel `"{}"` — also `"[]"` for this style, in `applyPatch` and in
   `createPlan` (`desiredset_process.go`). Missing it would issue a no-op `PATCH` on
   every reconcile.
3. `FakeApply` gets the passthrough needed to satisfy the interface.

## What is deliberately unchanged

`doPatch`, `GetPatchStyle`, `GetMergeStyle` and `patch.Apply` are untouched. A
`desiredSet` with no `nullSafePatch` entry for a GVK produces byte-identical patches to
today. This matters because `clients.Apply` is shared by every controller in Rancher —
the opt-in is per GVK, so enabling it for one kind leaves every other consumer
unaffected.

## Testing

Unit — `pkg/patch/jsonpatch_test.go`:

- an explicit null is assigned, not removed;
- a null for a key absent from `modified` is a removal;
- a removal of a key absent from `current` emits nothing;
- pointer tokens are escaped (RFC 6901 `~`→`~0`, `/`→`~1`, including `objectset.rio.cattle.io/applied`);
- arrays are replaced wholesale;
- a subtree missing from `current` is added wholesale with its nulls;
- a stale removal inside a new subtree is dropped;
- an object replacing a scalar is set wholesale;
- operations are emitted in a stable order;
- invalid input is rejected.

`pkg/apply/desiredset_compare_test.go`: `TestApplyPatchNullSafe` and
`TestSanitizePatchJSONPatch`.

Manual / integration — verified on a live cluster that the apiserver stores a null
written by `JSONPatchType` into an `x-kubernetes-preserve-unknown-fields` subtree rather
than pruning it. This is the one assumption no unit test can reach.

## Downstream

This PR alone fixes nothing; it adds a capability. The companion `rancher/rancher` PR
registers it for `RKEControlPlane`. Sequencing: merge here → tag → bump
`github.com/rancher/wrangler/v3` in `rancher/rancher` (currently `v3.7.1`) → merge the
Rancher PR. Each backport branch needs its own bump.

## Backport

New API surface only, no behaviour change for existing callers. Safe to backport to any
`v3.x` line that needs it.